### PR TITLE
cxp-357 move role grants to user resource

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -10,6 +10,9 @@
         ],
         "annotations": [
           {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipGrants"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {
@@ -88,7 +91,7 @@
         ],
         "annotations": [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
           },
           {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -21,7 +21,7 @@ var (
 			v2.ResourceType_TRAIT_USER,
 		},
 		Annotations: annotations.New(
-			&v2.SkipEntitlementsAndGrants{},
+			&v2.SkipEntitlements{},
 			capabilityPermissions(
 				"User Management: Read",
 				"User Management: Write",
@@ -35,6 +35,7 @@ var (
 			v2.ResourceType_TRAIT_ROLE,
 		},
 		Annotations: annotations.New(
+			&v2.SkipGrants{},
 			capabilityPermissions(
 				"User Management: Read",
 				"User Management: Write",

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -7,7 +7,6 @@ import (
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	"github.com/conductorone/baton-sdk/pkg/annotations"
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
-	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
@@ -124,148 +123,8 @@ func (r *roleResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 	return rv, nil, nil
 }
 
-func (r *roleResourceType) FindUsersWithRole(ctx context.Context, userIDs []string, roleId string) ([]string, []RateLimitInfo, error) {
-	rateLimitInfo := make([]RateLimitInfo, len(userIDs))
-
-	var users []string
-	for _, userId := range userIDs {
-		userRoles, err := r.client.UserManagement.CombinedUserRolesV1(
-			&user_management.CombinedUserRolesV1Params{
-				UserUUID: userId,
-				Context:  ctx,
-			},
-		)
-		if err != nil {
-			return nil, nil, wrapCrowdStrikeError(err, "find users with role: failed to get user roles")
-		}
-
-		rateLimitInfo = append(
-			rateLimitInfo,
-			NewRateLimitInfo(
-				userRoles.XRateLimitLimit,
-				userRoles.XRateLimitRemaining,
-			),
-		)
-
-		// check if user has role
-		for _, role := range userRoles.Payload.Resources {
-			if *role.RoleID == roleId {
-				users = append(users, userId)
-			}
-		}
-	}
-
-	return users, rateLimitInfo, nil
-}
-
-func (r *roleResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	rateLimitInfo := make([]RateLimitInfo, 0)
-	bag, offset, err := parsePageToken(opts.PageToken.Token, &v2.ResourceId{ResourceType: resourceTypeUser.Id})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// 1. get all user ids
-	userIDs, err := r.client.UserManagement.QueryUserV1(
-		&user_management.QueryUserV1Params{
-			Limit:   &ResourcesPageSize,
-			Offset:  &offset,
-			Context: ctx,
-		},
-	)
-	if err != nil {
-		return nil, nil, wrapCrowdStrikeError(err, "role grants: failed to query user ids")
-	}
-
-	// add rate limit info from listing user ids
-	rateLimitInfo = append(
-		rateLimitInfo,
-		NewRateLimitInfo(
-			userIDs.XRateLimitLimit,
-			userIDs.XRateLimitRemaining,
-		),
-	)
-
-	// continue syncing if no users are found
-	if len(userIDs.Payload.Resources) == 0 {
-		annos := WithRateLimitAnnotations(rateLimitInfo...)
-
-		return nil, &rs.SyncOpResults{Annotations: annos}, nil
-	}
-
-	nextPage, err := handleNextPage(bag, offset+ResourcesPageSize)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	isLastPage, err := userIDs.Payload.Meta.Pagination.LastPage()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if isLastPage {
-		nextPage = ""
-	}
-
-	// 2. find users that have this role
-	targetUserIDs, rlInfo, err := r.FindUsersWithRole(ctx, userIDs.Payload.Resources, resource.Id.Resource)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// add rate limit info from listing user roles
-	rateLimitInfo = append(rateLimitInfo, rlInfo...)
-
-	if len(targetUserIDs) == 0 {
-		annos := WithRateLimitAnnotations(rateLimitInfo...)
-
-		return nil, &rs.SyncOpResults{NextPageToken: nextPage, Annotations: annos}, nil
-	}
-
-	// 3. get details for users under fetched ids
-	users, err := r.client.UserManagement.RetrieveUsersGETV1(
-		&user_management.RetrieveUsersGETV1Params{
-			Body: &models.MsaspecIdsRequest{
-				Ids: targetUserIDs,
-			},
-			Context: ctx,
-		},
-	)
-	if err != nil {
-		return nil, nil, wrapCrowdStrikeError(err, "role grants: failed to retrieve user details")
-	}
-
-	// add rate limit info from listing user details
-	rateLimitInfo = append(
-		rateLimitInfo,
-		NewRateLimitInfo(
-			users.XRateLimitLimit,
-			users.XRateLimitRemaining,
-		),
-	)
-
-	// 4. create grants for users
-	var rv []*v2.Grant
-	for _, user := range users.Payload.Resources {
-		uID, err := rs.NewResourceID(resourceTypeUser, user.UUID)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create user resource id: %w", err)
-		}
-
-		rv = append(
-			rv,
-			grant.NewGrant(
-				resource,
-				roleMembership,
-				uID,
-			),
-		)
-	}
-
-	// annotations for rate limits
-	annos := WithRateLimitAnnotations(rateLimitInfo...)
-
-	return rv, &rs.SyncOpResults{NextPageToken: nextPage, Annotations: annos}, nil
+func (r *roleResourceType) Grants(_ context.Context, _ *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
 }
 
 func (r *roleResourceType) Grant(ctx context.Context, principal *v2.Resource, entitlement *v2.Entitlement) (annotations.Annotations, error) {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -139,6 +139,11 @@ func (u *userResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.S
 		rv = append(rv, ur)
 	}
 
+	if userIDs.Payload.Meta.Pagination == nil {
+		annos := WithRateLimitAnnotations(rateLimitInfo...)
+		return rv, &rs.SyncOpResults{Annotations: annos}, nil
+	}
+
 	isLastPage, err := userIDs.Payload.Meta.Pagination.LastPage()
 	if err != nil {
 		return nil, nil, err
@@ -198,6 +203,10 @@ func (u *userResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 	}
 
 	annos := WithRateLimitAnnotations(NewRateLimitInfo(resp.XRateLimitLimit, resp.XRateLimitRemaining))
+
+	if resp.Payload.Meta.Pagination == nil {
+		return rv, &rs.SyncOpResults{Annotations: annos}, nil
+	}
 
 	isLastPage, err := resp.Payload.Meta.Pagination.LastPage()
 	if err != nil {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -13,6 +13,8 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/models"
 )
 
+var userGrantsPageSize int64 = 500 // Default is 100, max is 500.
+
 type userResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
@@ -167,9 +169,16 @@ func (u *userResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 func (u *userResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	userID := resource.Id.Resource
 
+	bag, offset, err := parsePageToken(opts.PageToken.Token, resource.Id)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	resp, err := u.client.UserManagement.CombinedUserRolesV1(
 		&user_management.CombinedUserRolesV1Params{
 			UserUUID: userID,
+			Limit:    &userGrantsPageSize,
+			Offset:   &offset,
 			Context:  ctx,
 		},
 	)
@@ -189,7 +198,22 @@ func (u *userResourceType) Grants(ctx context.Context, resource *v2.Resource, op
 	}
 
 	annos := WithRateLimitAnnotations(NewRateLimitInfo(resp.XRateLimitLimit, resp.XRateLimitRemaining))
-	return rv, &rs.SyncOpResults{Annotations: annos}, nil
+
+	isLastPage, err := resp.Payload.Meta.Pagination.LastPage()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if isLastPage {
+		return rv, &rs.SyncOpResults{Annotations: annos}, nil
+	}
+
+	nextPage, err := handleNextPage(bag, offset+userGrantsPageSize)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rv, &rs.SyncOpResults{NextPageToken: nextPage, Annotations: annos}, nil
 }
 
 func userBuilder(client *fClient.CrowdStrikeAPISpecification) *userResourceType {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -2,9 +2,11 @@ package connector
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/crowdstrike/gofalcon/falcon/client/user_management"
@@ -163,7 +165,31 @@ func (u *userResourceType) Entitlements(ctx context.Context, resource *v2.Resour
 }
 
 func (u *userResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	return nil, nil, nil
+	userID := resource.Id.Resource
+
+	resp, err := u.client.UserManagement.CombinedUserRolesV1(
+		&user_management.CombinedUserRolesV1Params{
+			UserUUID: userID,
+			Context:  ctx,
+		},
+	)
+	if err != nil {
+		return nil, nil, wrapCrowdStrikeError(err, "user grants: failed to query user roles")
+	}
+
+	var rv []*v2.Grant
+	for _, roleGrant := range resp.Payload.Resources {
+		roleResID, err := rs.NewResourceID(resourceTypeRole, *roleGrant.RoleID)
+		if err != nil {
+			return nil, nil, fmt.Errorf("user grants: failed to create role resource id: %w", err)
+		}
+
+		roleRes := v2.Resource_builder{Id: roleResID}.Build()
+		rv = append(rv, grant.NewGrant(roleRes, roleMembership, resource))
+	}
+
+	annos := WithRateLimitAnnotations(NewRateLimitInfo(resp.XRateLimitLimit, resp.XRateLimitRemaining))
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func userBuilder(client *fClient.CrowdStrikeAPISpecification) *userResourceType {


### PR DESCRIPTION
#### Description

We moved roles grants to user resource to avoid listing the whole user list once per role resource and also avoid caching.



#### Useful links:

- [Baton SDK coding guidelines](https://github.com/ConductorOne/baton-sdk/wiki/Coding-Guidelines)
- [New contributor guide](https://github.com/ConductorOne/baton/blob/main/CONTRIBUTING.md)
