### PR TITLE
docs: add BATON_PROVISIONING flag to Kubernetes secrets config

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -175,6 +175,9 @@ stringData:
   BATON_CROWDSTRIKE_CLIENT_ID: <Client ID for the CrowdStrike API client>
   BATON_CROWDSTRIKE_CLIENT_SECRET: <Client secret for the CrowdStrike API client>
   BATON_REGION: <CrowdStrike region, options include 'us-1' (default), 'us-2', 'eu-1', and 'us-gov-1'>
+
+  # Optional: include if you want C1 to provision access using this connector
+  BATON_PROVISIONING: true
 ```
 
 See the connector's README or run `--help` to see all available configuration flags and environment variables.


### PR DESCRIPTION
## Summary

The `docs/connector.mdx` Kubernetes secrets configuration was missing `BATON_PROVISIONING: true`. Added the flag with the standard explanatory comment to match the pattern used in other provisioning-capable connector docs.

This mirrors the fix applied to the main ConductorOne/docs site in PR #245.