### PR TITLE
docs: update style to match docs site

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -51,7 +51,7 @@ A user with the **Falcon Administrator** role in CrowdStrike must perform this t
   </Step>
 </Steps>
 
-**That's it!** Next, move on to the connector configuration instructions.
+**Done.** Next, move on to the connector configuration instructions.
 
 ## Configure the CrowdStrike connector
 
@@ -105,7 +105,7 @@ To complete this task, you'll need:
   </Step>
 </Steps>
 
-**That's it!** Your CrowdStrike connector is now pulling access data into C1.
+**Done.** Your CrowdStrike connector is now pulling access data into C1.
 
 </Tab>
 <Tab title="Self-hosted">
@@ -226,7 +226,7 @@ spec:
   </Step>
 </Steps>
 
-**That's it!** Your CrowdStrike connector is now pulling access data into C1.
+**Done.** Your CrowdStrike connector is now pulling access data into C1.
 
 </Tab>
 </Tabs>
@@ -270,4 +270,4 @@ The CrowdStrike API client you created during connector setup needs additional s
   </Step>
 </Steps>
 
-**That's it!** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
+**Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.


### PR DESCRIPTION
## Summary

Syncs `docs/connector.mdx` style with the canonical docs site to prevent regressions on next release.

Changes applied where present:
- Docker image URL: `ghcr.io/conductorone/` → `public.ecr.aws/conductorone/`
- Phrasing: `**That's it!**` → `**Done.**`
- Icon color: `#65DE23` → `#c937ae`
- Branding: `ConductorOne` → `C1` in product references
- GitHub URLs: lowercased org name

These match the [docs site](https://docs.conductorone.com) and were identified via an automated sync audit.