### PR TITLE
feat(mcp_server): discover shadow MCP servers and correlate to identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `baton-crowdstrike` [![Go Reference](https://pkg.go.dev/badge/github.com/conductorone/baton-crowdstrike.svg)](https://pkg.go.dev/github.com/conductorone/baton-crowdstrike) ![verify](https://github.com/conductorone/baton-crowdstrike/actions/workflows/verify.yaml/badge.svg)
 
-`baton-crowdstrike` is a connector for CrowdStrike built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It works with the CrowdStrike Falcon API to sync users, roles, and identity risk scores, with provisioning support for account creation/deletion, role membership, and user profile updates.
+`baton-crowdstrike` is a connector for CrowdStrike built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It works with the CrowdStrike Falcon API to sync users, roles, identity risk scores, and shadow MCP servers, with provisioning support for account creation/deletion, role membership, and user profile updates.
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more about the project in general.
 
@@ -18,6 +18,7 @@ The connector requires a **client ID and secret** to exchange for an access toke
 | **User Management: Write**             | For provisioning  | Create/delete users, grant/revoke roles, update name |
 | **Identity Protection Entities: Read** | For risk scores   | Sync identity risk scores (opt-in `security_insight`)|
 | **Identity Protection GraphQL: Write** | For risk scores   | Required by CrowdStrike to fetch risk score data     |
+| **Alerts: Read**                       | For shadow MCP    | Read EDR detections to discover shadow MCP servers and their endpoint users (`mcp_server`, `endpoint_user`) |
 
 # Getting Started
 
@@ -67,11 +68,15 @@ baton resources
 - **Users** (`user`) — Falcon console users; `uuid` is the stable resource ID and `uid` is the login/email
 - **Roles** (`role`) — Falcon roles (e.g. `falcon_administrator`, `falcon_analyst`, `falcon_read_only`) with a `member` assignment entitlement
 - **Identity Risk Scores** (`security_insight`) — Falcon Identity Protection risk scores (opt-in, disabled by default)
+- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (see below)
+- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually)
 
 | Resource             | Sync | Provision                                          |
 | -------------------- | ---- | -------------------------------------------------- |
 | Users                | Yes  | Yes (create / delete, and update first/last name)  |
 | Roles                | Yes  | Yes (Grant / Revoke role membership)               |
+| Shadow MCP Servers   | Yes  | No                                                 |
+| Endpoint Users       | Yes  | No                                                 |
 | Identity Risk Scores | Yes  | No (synced read-only, opt-in)                      |
 
 # Provisioning
@@ -151,6 +156,26 @@ The connector can sync identity risk scores from CrowdStrike Identity Protection
 - **Risk Factors**: The factors contributing to the risk score (e.g. "WEAK_PASSWORD (HIGH)", "MFA_NOT_ENABLED (MEDIUM)")
 
 To sync security insights, your CrowdStrike API client must have the **Identity Protection Entities: Read** and **Identity Protection GraphQL: Write** scopes enabled. The `security_insight` resource type is disabled by default and can be enabled through ConductorOne.
+
+# Shadow MCP Servers
+
+The connector discovers unsanctioned ("shadow") [Model Context Protocol](https://modelcontextprotocol.io) servers running on managed endpoints and correlates each to the identity that ran it — surfacing ungoverned AI-agent tooling that never passed through a sanctioned gateway.
+
+An MCP server is an ordinary `npx` / `uvx` / `node` / `python` process whose command line carries a recognizable package (`@modelcontextprotocol/server-*`, `mcp-server-*`, `mcp_server_*`) — the **MCP signature**. The connector reads CrowdStrike EDR detections (via the Alerts API), matches that signature, deduplicates by (host, endpoint user, server), and emits one `mcp_server` resource per instance with:
+
+- an **App-trait profile**: `server_name`, `package`, `launcher`, `transport`, `host`, `aid`, `local_ip`, `endpoint_user`, `sample_command_line`, `detection_count`, `ioa_rule`, `falcon_link`, `sanctioned` (always `false`), plus `first_seen` when a detection timestamp is available and `identity_email` / `identity_external_id` / `identity_display_name` when the endpoint user resolves to an Identity Protection entity;
+- a **security-insight** issue (always `High`) bound to that identity (`AppUser` target), so the finding flows into the identity's risk in ConductorOne.
+
+### Account & grant chain
+
+Correlation is also modeled as a normal account/entitlement/grant chain, so a shadow MCP shows up against a real person in access reviews — not just as profile metadata:
+
+- each shadow-MCP instance produces an **`endpoint_user`** account resource (the OS user that ran it), matched to a ConductorOne identity by email when the endpoint user resolves to an Identity Protection entity, or **assignable manually** otherwise;
+- each `mcp_server` resource exposes a **`runner`** assignment entitlement, granted to the `endpoint_user` account that ran it.
+
+The result is a **c1 identity → `endpoint_user` account → `runner` grant → `mcp_server`** chain, alongside the identity-risk security insight above.
+
+To detect the servers natively, author a **Custom IOA** rule (Process Creation, Detect disposition) matching the command-line signature `(@modelcontextprotocol/server-|mcp-server-|mcp_server_)` so CrowdStrike raises a detection the connector can read. Endpoint users are resolved to identities via Identity Protection `samAccountName` (or email local-part). The `mcp_server` and `endpoint_user` resource types both require the **Alerts: Read** scope (plus the Identity Protection scopes above for correlation).
 
 # Contributing, Support and Issues
 

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -3,6 +3,86 @@
   "resourceTypeCapabilities": [
     {
       "resourceType": {
+        "id": "endpoint_user",
+        "displayName": "Endpoint User",
+        "traits": [
+          "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
+        "id": "mcp_server",
+        "displayName": "Shadow MCP Server",
+        "traits": [
+          "TRAIT_APP",
+          "TRAIT_SECURITY_INSIGHT"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              },
+              {
+                "permission": "Identity Protection GraphQL: Write"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          },
+          {
+            "permission": "Identity Protection GraphQL: Write"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
         "id": "role",
         "displayName": "Role",
         "traits": [

--- a/config_schema.json
+++ b/config_schema.json
@@ -130,6 +130,18 @@
           ]
         }
       }
+    },
+    {
+      "name": "crowdstrike-ingest-risk-scores",
+      "displayName": "Ingest identity risk scores",
+      "description": "Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors as security insights on identities. Off by default; requires the Identity Protection scopes.",
+      "boolField": {}
+    },
+    {
+      "name": "crowdstrike-detect-shadow-mcp",
+      "displayName": "Detect shadow MCP servers",
+      "description": "Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint users that ran them, correlated to identities. Off by default; requires the Alerts read scope.",
+      "boolField": {}
     }
   ],
   "displayName": "CrowdStrike",

--- a/config_schema.json
+++ b/config_schema.json
@@ -134,8 +134,10 @@
     {
       "name": "crowdstrike-ingest-risk-scores",
       "displayName": "Ingest identity risk scores",
-      "description": "Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors as security insights on identities. Off by default; requires the Identity Protection scopes.",
-      "boolField": {}
+      "description": "On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as security insights on identities; requires the Identity Protection scopes. Turn off to disable.",
+      "boolField": {
+        "defaultValue": true
+      }
     },
     {
       "name": "crowdstrike-detect-shadow-mcp",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -12,7 +12,7 @@ sidebarTitle: "CrowdStrike"
 | :--- | :--- | :--- |
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Insights (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Insights | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
@@ -278,9 +278,9 @@ The CrowdStrike API client you created during connector setup needs additional s
   </Step>
 </Steps>
 
-### Turn on risk score ingestion
+### Risk score ingestion setting
 
-In C1, open the connector's **Settings** and enable **Ingest identity risk scores** (off by default), then save.
+Risk score ingestion is **on by default**. Once the scopes above are in place, the connector syncs it automatically — no further action needed. To disable it, open the connector's **Settings** in C1, turn off **Ingest identity risk scores**, and save.
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -278,6 +278,10 @@ The CrowdStrike API client you created during connector setup needs additional s
   </Step>
 </Steps>
 
+### Turn on risk score ingestion
+
+In C1, open the connector's **Settings** and enable **Ingest identity risk scores** (off by default), then save.
+
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
 
 ## Detect shadow MCP servers
@@ -340,5 +344,9 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
   Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
   </Step>
 </Steps>
+
+### Turn on shadow MCP detection
+
+In C1, open the connector's **Settings** and enable **Detect shadow MCP servers** (off by default), then save.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -13,6 +13,8 @@ sidebarTitle: "CrowdStrike"
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Insights (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
 ### Connector actions
 
@@ -277,3 +279,66 @@ The CrowdStrike API client you created during connector setup needs additional s
 </Steps>
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
+
+## Detect shadow MCP servers
+
+<Warning>
+**Early access.** This feature is in early access, which means it's undergoing ongoing testing and development while we gather feedback, validate functionality, and improve outputs. Contact the C1 Support team if you'd like to try it out or share feedback.
+</Warning>
+
+The CrowdStrike connector can surface unsanctioned ("shadow") [Model Context Protocol](https://modelcontextprotocol.io) servers running on your endpoints — ungoverned AI-agent tooling that never passed through a sanctioned gateway — and correlate each to the identity that ran it. It reads CrowdStrike endpoint detections and models each shadow server as:
+
+- an **`mcp_server`** resource describing the server (package, launcher, transport, host, sample command line, and the identity it resolved to), and
+- an **`endpoint_user`** account for the OS user that ran it, holding a **runner** grant on that server.
+
+Assign the endpoint-user account to a C1 identity (or it auto-matches by email when the endpoint user resolves in Identity Protection) so the shadow MCP shows up against a real person in access reviews.
+
+### Before you begin
+
+Confirm that:
+
+- Your CrowdStrike environment generates endpoint detections (the connector reads them via the Alerts API)
+- You have the **Falcon Administrator** role in CrowdStrike
+- Your CrowdStrike connector is already set up and syncing in C1
+
+### Add the required API scope
+
+<Steps>
+  <Step>
+  Sign into the Falcon console and navigate to **Support** > **API Clients and Keys**.
+  </Step>
+  <Step>
+  Find the API client you created for the C1 integration and click to edit it.
+  </Step>
+  <Step>
+  In the **API SCOPES** section, enable **Alerts: Read**. Keep the **Identity Protection Entities: Read** scope enabled (from risk score ingestion) so endpoint users can be matched to identities.
+  </Step>
+  <Step>
+  Click **Save**.
+  </Step>
+</Steps>
+
+### Create a detection rule for MCP servers
+
+CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule that raises a detection the connector can read. An MCP server is an ordinary `npx`, `uvx`, `node`, or `python` process whose command line contains a recognizable package name (`@modelcontextprotocol/server-*`, `mcp-server-*`, or `mcp_server_*`).
+
+<Steps>
+  <Step>
+  In the Falcon console, create or open a **Custom IOA rule group** for each platform you want to cover (Windows, macOS, Linux).
+  </Step>
+  <Step>
+  Add a **Process Creation** rule with the **Detect** disposition.
+  </Step>
+  <Step>
+  Set the rule's **Command Line** field to match the MCP signature:
+
+  ```
+  (?i).*(@modelcontextprotocol/server-|mcp-server-|mcp_server_).*
+  ```
+  </Step>
+  <Step>
+  Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
+  </Step>
+</Steps>
+
+**Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	go.uber.org/zap v1.28.0
-	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -147,6 +146,7 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,8 @@ type Crowdstrike struct {
 	CrowdstrikeClientSecret string `mapstructure:"crowdstrike-client-secret"`
 	Region string `mapstructure:"region"`
 	BaseUrl string `mapstructure:"base-url"`
+	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
+	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,20 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
+	IngestRiskScoresField = field.BoolField(
+		"crowdstrike-ingest-risk-scores",
+		field.WithDisplayName("Ingest identity risk scores"),
+		field.WithDescription("Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors "+
+			"as security insights on identities. Off by default; requires the Identity Protection scopes."),
+		field.WithDefaultValue(false),
+	)
+	DetectShadowMCPField = field.BoolField(
+		"crowdstrike-detect-shadow-mcp",
+		field.WithDisplayName("Detect shadow MCP servers"),
+		field.WithDescription("Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint "+
+			"users that ran them, correlated to identities. Off by default; requires the Alerts read scope."),
+		field.WithDefaultValue(false),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
@@ -39,6 +53,8 @@ var (
 		ClientSecretField,
 		RegionField,
 		BaseURLField,
+		IngestRiskScoresField,
+		DetectShadowMCPField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,9 +34,9 @@ var (
 	IngestRiskScoresField = field.BoolField(
 		"crowdstrike-ingest-risk-scores",
 		field.WithDisplayName("Ingest identity risk scores"),
-		field.WithDescription("Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors "+
-			"as security insights on identities. Off by default; requires the Identity Protection scopes."),
-		field.WithDefaultValue(false),
+		field.WithDescription("On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as "+
+			"security insights on identities; requires the Identity Protection scopes. Turn off to disable."),
+		field.WithDefaultValue(true),
 	)
 	DetectShadowMCPField = field.BoolField(
 		"crowdstrike-detect-shadow-mcp",

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,21 +17,23 @@ import (
 )
 
 type Connector struct {
-	client       *fClient.CrowdStrikeAPISpecification
-	clientId     string
-	clientSecret string
-	host         string
+	client           *fClient.CrowdStrikeAPISpecification
+	clientId         string
+	clientSecret     string
+	host             string
+	ingestRiskScores bool
+	detectShadowMCP  bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
 	// a single per-sync detection snapshot + identity index (consistent grants, no
 	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host)
+	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host, o.detectShadowMCP)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host),
+		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host, o.ingestRiskScores),
 		mcpServerBuilder(o.client, mcpSrc),
 		endpointUserBuilder(mcpSrc),
 	}
@@ -152,9 +154,11 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 	}
 
 	return &Connector{
-		client:       client,
-		clientId:     cc.CrowdstrikeClientId,
-		clientSecret: cc.CrowdstrikeClientSecret,
-		host:         host,
+		client:           client,
+		clientId:         cc.CrowdstrikeClientId,
+		clientSecret:     cc.CrowdstrikeClientSecret,
+		host:             host,
+		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
+		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	cfg "github.com/conductorone/baton-crowdstrike/pkg/config"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -18,8 +19,7 @@ import (
 
 type Connector struct {
 	client           *fClient.CrowdStrikeAPISpecification
-	clientId         string
-	clientSecret     string
+	httpClient       *uhttp.BaseHttpClient
 	host             string
 	ingestRiskScores bool
 	detectShadowMCP  bool
@@ -29,11 +29,11 @@ func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
 	// a single per-sync detection snapshot + identity index (consistent grants, no
 	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host, o.detectShadowMCP)
+	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host, o.ingestRiskScores),
+		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores),
 		mcpServerBuilder(o.client, mcpSrc),
 		endpointUserBuilder(mcpSrc),
 	}
@@ -153,10 +153,26 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		host = cc.BaseUrl
 	}
 
+	// The Identity Protection (GraphQL) and Alerts APIs share the same OAuth2
+	// client-credentials grant against the same host, so one uhttp base client
+	// serves both.
+	tokenURL, err := url.Parse("https://" + host + "/oauth2/token")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse oauth2 token url: %w", err)
+	}
+	oauthCreds := uhttp.NewOAuth2ClientCredentials(cc.CrowdstrikeClientId, cc.CrowdstrikeClientSecret, tokenURL, nil)
+	oauthClient, err := oauthCreds.GetClient(ctx, uhttp.WithUserAgent("baton-crowdstrike"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create oauth2 http client: %w", err)
+	}
+	httpClient, err := uhttp.NewBaseHttpClientWithContext(ctx, oauthClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create base http client: %w", err)
+	}
+
 	return &Connector{
 		client:           client,
-		clientId:         cc.CrowdstrikeClientId,
-		clientSecret:     cc.CrowdstrikeClientSecret,
+		httpClient:       httpClient,
 		host:             host,
 		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
 		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,10 +24,16 @@ type Connector struct {
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
+	// a single per-sync detection snapshot + identity index (consistent grants, no
+	// redundant Alerts / Identity-Protection calls).
+	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
 		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host),
+		mcpServerBuilder(o.client, mcpSrc),
+		endpointUserBuilder(mcpSrc),
 	}
 }
 

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -256,6 +256,7 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
+	//nolint:gosec // endpoint host derives from the configured CrowdStrike region, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -166,17 +166,16 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
 // IdentityProtectionClient provides methods to interact with CrowdStrike's Identity Protection API.
 type IdentityProtectionClient struct {
 	httpClient *uhttp.BaseHttpClient
-	endpoint   *url.URL
+	host       string
 }
 
 // NewIdentityProtectionClient creates a new Identity Protection client that talks to CrowdStrike's
 // GraphQL API over the given shared uhttp base client (OAuth2 client-credentials, transient-error
 // retries, and rate-limit metadata all handled by uhttp).
 func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string) *IdentityProtectionClient {
-	endpoint, _ := url.Parse("https://" + host + "/identity-protection/combined/graphql/v1")
 	return &IdentityProtectionClient{
 		httpClient: httpClient,
-		endpoint:   endpoint,
+		host:       host,
 	}
 }
 
@@ -196,7 +195,12 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 		Variables: variables,
 	}
 
-	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, c.endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
+	endpoint, err := url.Parse("https://" + c.host + "/identity-protection/combined/graphql/v1")
+	if err != nil {
+		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: invalid identity protection endpoint for host %q: %w", c.host, err)
+	}
+
+	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to create HTTP request: %w", err)
 	}

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -1,16 +1,13 @@
 package connector
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"strings"
-	"time"
 
-	"golang.org/x/oauth2/clientcredentials"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
 // AccountData represents an external account descriptor associated with an identity entity.
@@ -168,61 +165,19 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
 
 // IdentityProtectionClient provides methods to interact with CrowdStrike's Identity Protection API.
 type IdentityProtectionClient struct {
-	httpClient *http.Client
-	endpoint   string
+	httpClient *uhttp.BaseHttpClient
+	endpoint   *url.URL
 }
 
-// NewIdentityProtectionClient creates a new Identity Protection client with OAuth2 authentication.
-func NewIdentityProtectionClient(ctx context.Context, clientID, clientSecret, host string) *IdentityProtectionClient {
-	// Create OAuth2 client credentials config
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-
-	// Create the OAuth2 HTTP client
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
-
-	// Wrap the transport to add user-agent header
-	httpClient.Transport = &identityProtectionTransport{
-		base: httpClient.Transport,
-	}
-
+// NewIdentityProtectionClient creates a new Identity Protection client that talks to CrowdStrike's
+// GraphQL API over the given shared uhttp base client (OAuth2 client-credentials, transient-error
+// retries, and rate-limit metadata all handled by uhttp).
+func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string) *IdentityProtectionClient {
+	endpoint, _ := url.Parse("https://" + host + "/identity-protection/combined/graphql/v1")
 	return &IdentityProtectionClient{
 		httpClient: httpClient,
-		endpoint:   "https://" + host + "/identity-protection/combined/graphql/v1",
+		endpoint:   endpoint,
 	}
-}
-
-// identityProtectionTransport adds custom headers to requests.
-type identityProtectionTransport struct {
-	base http.RoundTripper
-}
-
-func (t *identityProtectionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "baton-crowdstrike")
-	if t.base == nil {
-		return http.DefaultTransport.RoundTrip(req)
-	}
-	return t.base.RoundTrip(req)
-}
-
-// RefreshContext updates the OAuth2 context used for token refresh.
-// This should be called before making requests to ensure the token can be refreshed.
-func (c *IdentityProtectionClient) RefreshContext(ctx context.Context, clientID, clientSecret, host string) {
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
-	httpClient.Transport = &identityProtectionTransport{
-		base: httpClient.Transport,
-	}
-	c.httpClient = httpClient
 }
 
 // GetIdentityRiskScores fetches identity risk scores from CrowdStrike Identity Protection.
@@ -241,45 +196,23 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 		Variables: variables,
 	}
 
-	// Create the request body
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to marshal GraphQL request: %w", err)
-	}
-
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(bodyBytes))
+	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, c.endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to create HTTP request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)
+	var graphQLResp graphQLResponse
+	resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&graphQLResp))
+	if resp == nil {
+		return nil, "", false, RateLimitInfo{}, err
 	}
 	defer resp.Body.Close()
 
-	// Extract rate limit info from response headers
+	// Extract rate limit info from response headers, even on error, so callers can
+	// still surface rate-limit annotations for a failed request.
 	rateLimitInfo := extractRateLimitInfo(resp)
-
-	// Check for error status codes
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: identity protection API returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	// Parse the response body
-	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: failed to read response body: %w", err)
-	}
-
-	var graphQLResp graphQLResponse
-	if err := json.Unmarshal(respBody, &graphQLResp); err != nil {
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: failed to parse GraphQL response: %w", err)
+		return nil, "", false, rateLimitInfo, err
 	}
 
 	// Check for GraphQL errors

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -256,7 +256,6 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	//nolint:gosec // endpoint host derives from the configured CrowdStrike region, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -670,6 +670,11 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 // snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
 // that independent re-fetches would cause. Only the current sync's data is retained.
 type mcpSource struct {
+	// enabled gates shadow-MCP detection. When false (the default), detections and
+	// the identity index are no-ops that make no CrowdStrike API calls, so the
+	// mcp_server / endpoint_user syncers produce nothing — the capability is opt-in.
+	enabled bool
+
 	detClient *mcpDetectionsClient
 	ipClient  *IdentityProtectionClient
 
@@ -680,14 +685,18 @@ type mcpSource struct {
 	idxData map[string]*resolvedIdentity
 }
 
-func newMCPSource(ctx context.Context, clientID, clientSecret, host string) *mcpSource {
+func newMCPSource(ctx context.Context, clientID, clientSecret, host string, enabled bool) *mcpSource {
 	return &mcpSource{
+		enabled:   enabled,
 		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
 		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
 	}
 }
 
 func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
+	if !s.enabled {
+		return nil, nil
+	}
 	s.mu.Lock()
 	if s.detData != nil && s.detSync == syncID {
 		d := s.detData
@@ -706,6 +715,9 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 }
 
 func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
+	if !s.enabled {
+		return map[string]*resolvedIdentity{}, nil
+	}
 	s.mu.Lock()
 	if s.idxData != nil && s.idxSync == syncID {
 		idx := s.idxData

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -28,6 +28,9 @@ import (
 // by the endpoint user that ran the server.
 const mcpRunnerEntitlement = "runner"
 
+// launcherUnknown marks a detection whose command line doesn't name a known launcher.
+const launcherUnknown = "unknown"
+
 // mcpServerAlertLimit is how many recent alerts we pull to scan for shadow-MCP activity.
 const mcpServerAlertLimit = 1000
 
@@ -234,7 +237,7 @@ func buildInstances(dets []mcpDetection) map[string]*mcpServerInstance {
 		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
 			inst.det.Timestamp = d.Timestamp
 		}
-		if inst.launcher == "unknown" && launcher != "unknown" {
+		if inst.launcher == launcherUnknown && launcher != launcherUnknown {
 			inst.launcher = launcher
 			inst.transport = transport
 		}
@@ -422,29 +425,32 @@ func resolveIdentity(index map[string]*resolvedIdentity, userName string) *resol
 	return nil
 }
 
-// parseMCPServer extracts the MCP server identity from a process command line.
-func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok bool) {
+// parseMCPServer extracts the MCP server identity from a process command line,
+// returning (name, package, launcher, transport, matched).
+func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 	match := mcpSignature.FindString(cmdline)
 	if match == "" {
 		return "", "", "", "", false
 	}
 	// A bare .js entrypoint (e.g. mcp-server-fetch.js) and its package name are the same
 	// logical server; drop the extension so they don't split into two resources.
-	match = strings.TrimSuffix(match, ".js")
-	pkg = match
+	pkg := strings.TrimSuffix(match, ".js")
+
 	// Derive a short logical name from the package suffix.
+	var name string
 	switch {
-	case strings.HasPrefix(match, "@modelcontextprotocol/server-"):
-		name = strings.TrimPrefix(match, "@modelcontextprotocol/server-")
-	case strings.HasPrefix(match, "mcp-server-"):
-		name = strings.TrimPrefix(match, "mcp-server-")
-	case strings.HasPrefix(match, "mcp_server_"):
-		name = strings.TrimPrefix(match, "mcp_server_")
+	case strings.HasPrefix(pkg, "@modelcontextprotocol/server-"):
+		name = strings.TrimPrefix(pkg, "@modelcontextprotocol/server-")
+	case strings.HasPrefix(pkg, "mcp-server-"):
+		name = strings.TrimPrefix(pkg, "mcp-server-")
+	case strings.HasPrefix(pkg, "mcp_server_"):
+		name = strings.TrimPrefix(pkg, "mcp_server_")
 	default:
-		name = match
+		name = pkg
 	}
 
 	lc := strings.ToLower(cmdline)
+	launcher := launcherUnknown
 	switch {
 	case strings.Contains(lc, "npx"):
 		launcher = "npx"
@@ -454,11 +460,9 @@ func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok b
 		launcher = "python"
 	case strings.Contains(lc, "node"):
 		launcher = "node"
-	default:
-		launcher = "unknown"
 	}
 
-	transport = "stdio"
+	transport := "stdio"
 	if strings.Contains(lc, "--sse") || strings.Contains(lc, "transport sse") || strings.Contains(lc, "--port") {
 		transport = "sse/http"
 	}
@@ -523,6 +527,7 @@ func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body stri
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	//nolint:gosec // url is built from the connector's configured CrowdStrike region host, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -1,0 +1,672 @@
+package connector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	fClient "github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// mcpRunnerEntitlement is the assignment entitlement on an mcp_server resource held
+// by the endpoint user that ran the server.
+const mcpRunnerEntitlement = "runner"
+
+// mcpServerAlertLimit is how many recent alerts we pull to scan for shadow-MCP activity.
+const mcpServerAlertLimit = 1000
+
+// mcpSignature matches the command line of a Model Context Protocol server. MCP
+// servers are ordinary npx/uvx/node/python processes whose command line carries a
+// recognizable package: @modelcontextprotocol/server-*, mcp-server-*, mcp_server_*.
+var mcpSignature = regexp.MustCompile(`(?i)(@modelcontextprotocol/server-[\w.-]+|mcp-server-[\w.-]+|mcp_server_[\w.-]+)`)
+
+// mcpServerResourceType syncs unsanctioned ("shadow") MCP servers observed on
+// endpoints via CrowdStrike EDR detections, correlates each to the identity that
+// ran it, and emits a queryable resource plus an identity-risk insight.
+type mcpServerResourceType struct {
+	resourceType *v2.ResourceType
+	client       *fClient.CrowdStrikeAPISpecification
+	src          *mcpSource
+}
+
+func (m *mcpServerResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return m.resourceType
+}
+
+// mcpDetection is a single shadow-MCP process-creation detection from the Alerts API.
+type mcpDetection struct {
+	Hostname    string
+	AID         string
+	LocalIP     string
+	UserName    string
+	CommandLine string
+	FilePath    string
+	Timestamp   time.Time
+	CompositeID string
+	FalconLink  string
+	IOARuleName string
+}
+
+// mcpServerInstance is a deduplicated (host, user, server) shadow-MCP server. The
+// same logical server surfaces under several command-line spellings across the
+// process tree; we collapse them and keep the most informative representation.
+type mcpServerInstance struct {
+	det         mcpDetection
+	serverName  string
+	pkg         string
+	launcher    string
+	transport   string
+	bestCmdline string // shortest signature-bearing command line (cleanest sample)
+	count       int
+}
+
+// resolvedIdentity carries the identity a detection's OS user maps to.
+type resolvedIdentity struct {
+	email       string
+	externalID  string
+	displayName string
+}
+
+// List scans recent EDR detections for shadow-MCP activity, correlates each to an
+// identity, and returns one mcp_server resource per unique server instance.
+func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	dets, err := m.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+
+	// Build an identity lookup keyed by lowercased samAccountName and email local-part.
+	idIndex, err := m.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to build identity index: %w", err)
+	}
+
+	instances := buildInstances(dets)
+
+	resources := make([]*v2.Resource, 0, len(instances))
+	for _, inst := range instances {
+		id := resolveIdentity(idIndex, inst.det.UserName)
+		res, err := mcpServerResource(inst, id)
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build mcp_server resource: %w", err)
+		}
+		resources = append(resources, res)
+	}
+
+	return resources, &rs.SyncOpResults{}, nil
+}
+
+// Entitlements exposes a single "runner" assignment on each mcp_server resource,
+// grantable to the endpoint user that ran the server.
+func (m *mcpServerResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	opts := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeEndpointUser),
+		ent.WithDisplayName(fmt.Sprintf("%s runner", resource.DisplayName)),
+		ent.WithDescription("Endpoint user that ran this shadow MCP server"),
+	}
+	return []*v2.Entitlement{ent.NewAssignmentEntitlement(resource, mcpRunnerEntitlement, opts...)}, nil, nil
+}
+
+// Grants gives the endpoint-user account the "runner" entitlement on the mcp_server
+// resource it ran. The account is synced separately (see endpoint_user) and is
+// auto-matched to a c1 identity by email or assigned manually; this grant is what
+// surfaces it as the resource's principal.
+func (m *mcpServerResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	dets, err := m.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server grants: failed to fetch detections: %w", err)
+	}
+	for _, inst := range buildInstances(dets) {
+		if inst.objectID() != resource.Id.Resource {
+			continue
+		}
+		principal := &v2.ResourceId{ResourceType: resourceTypeEndpointUser.Id, Resource: inst.accountID()}
+		return []*v2.Grant{grant.NewGrant(resource, mcpRunnerEntitlement, principal)}, nil, nil
+	}
+	return nil, nil, nil
+}
+
+// mcpServerResource builds an mcp_server resource: an App-trait profile carrying the
+// full server + endpoint + identity metadata, plus a security-insight annotation
+// that binds a shadow-MCP finding to the resolved identity (when one is found).
+func mcpServerResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+
+	displayName := fmt.Sprintf("Shadow MCP: %s @ %s", inst.serverName, d.Hostname)
+	if d.UserName != "" {
+		displayName = fmt.Sprintf("%s (%s)", displayName, d.UserName)
+	}
+
+	profile := map[string]interface{}{
+		"server_name":         inst.serverName,
+		"package":             inst.pkg,
+		"launcher":            inst.launcher,
+		"transport":           inst.transport,
+		"sanctioned":          false,
+		"endpoint_user":       d.UserName,
+		"host":                d.Hostname,
+		"aid":                 d.AID,
+		"local_ip":            d.LocalIP,
+		"sample_command_line": inst.bestCmdline,
+		"detection_count":     inst.count,
+		"ioa_rule":            d.IOARuleName,
+		"falcon_link":         d.FalconLink,
+	}
+	if !d.Timestamp.IsZero() {
+		profile["first_seen"] = d.Timestamp.UTC().Format(time.RFC3339)
+	}
+	if id != nil {
+		profile["identity_email"] = id.email
+		profile["identity_external_id"] = id.externalID
+		profile["identity_display_name"] = id.displayName
+	}
+
+	opts := []rs.ResourceOption{
+		rs.WithAppTrait(rs.WithAppProfile(profile)),
+	}
+
+	// Bind the finding to the identity as a security insight (issue) so it flows into
+	// c1 identity risk. Requires a resolved identity with an external ID.
+	if id != nil && id.externalID != "" {
+		issueVal := fmt.Sprintf("Shadow MCP server '%s' (%s via %s/%s) running on %s as %s",
+			inst.serverName, inst.pkg, inst.launcher, inst.transport, d.Hostname, d.UserName)
+		insightOpts := []rs.SecurityInsightTraitOption{
+			rs.WithIssue(issueVal),
+			rs.WithIssueSeverity("High"),
+			rs.WithInsightAppUserTarget(id.email, id.externalID),
+		}
+		if !d.Timestamp.IsZero() {
+			insightOpts = append(insightOpts, rs.WithInsightObservedAt(d.Timestamp))
+		}
+		insight, err := rs.NewSecurityInsightTrait(insightOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build security insight trait: %w", err)
+		}
+		opts = append(opts, rs.WithAnnotation(insight))
+	}
+
+	return rs.NewResource(displayName, resourceTypeMCPServer, inst.objectID(), opts...)
+}
+
+// buildInstances deduplicates detections into unique server instances, keyed by the
+// logical server (host, user, server name) so the different command-line spellings of
+// the same server (e.g. "node ... @modelcontextprotocol/server-everything" and
+// "sh -c mcp-server-everything") collapse into one resource.
+func buildInstances(dets []mcpDetection) map[string]*mcpServerInstance {
+	instances := map[string]*mcpServerInstance{}
+	for _, d := range dets {
+		if d.AID == "" || d.UserName == "" {
+			continue // unattributable — avoid collapsing distinct hosts/users into one id
+		}
+		name, pkg, launcher, transport, ok := parseMCPServer(d.CommandLine)
+		if !ok {
+			continue
+		}
+		key := strings.Join([]string{d.AID, strings.ToLower(d.UserName), name}, "|")
+		inst, seen := instances[key]
+		if !seen {
+			instances[key] = &mcpServerInstance{
+				det: d, serverName: name, pkg: pkg, launcher: launcher, transport: transport,
+				bestCmdline: d.CommandLine, count: 1,
+			}
+			continue
+		}
+		inst.count++
+		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
+			inst.det.Timestamp = d.Timestamp
+		}
+		if inst.launcher == "unknown" && launcher != "unknown" {
+			inst.launcher = launcher
+			inst.transport = transport
+		}
+		if strings.HasPrefix(pkg, "@modelcontextprotocol/") {
+			inst.pkg = pkg
+		}
+		if len(d.CommandLine) < len(inst.bestCmdline) {
+			inst.bestCmdline = d.CommandLine
+		}
+	}
+	return instances
+}
+
+// objectID is the stable mcp_server resource ID. It hashes aid|user|serverName — the
+// same fields buildInstances dedups on — so the ID is stable across syncs regardless of
+// which command-line spelling (mcp-server-x vs @modelcontextprotocol/server-x) happens
+// to appear in a given alert window, and always agrees with the dedup key.
+func (inst *mcpServerInstance) objectID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName), inst.serverName}, "|")))
+	return "mcp-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// accountID is the stable endpoint_user account ID (sha256 of aid|user), shared by
+// every server the same user ran on the same host.
+func (inst *mcpServerInstance) accountID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName)}, "|")))
+	return "eu-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// endpointUserResourceType syncs the endpoint OS users that ran shadow MCP servers as
+// app accounts, so they can be assigned to a ConductorOne identity and shown against
+// the mcp_server resources they ran.
+type endpointUserResourceType struct {
+	resourceType *v2.ResourceType
+	src          *mcpSource
+}
+
+func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return e.resourceType
+}
+
+func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	dets, err := e.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	idIndex, err := e.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to build identity index: %w", err)
+	}
+
+	seen := map[string]bool{}
+	var rv []*v2.Resource
+	for _, inst := range buildInstances(dets) {
+		acctID := inst.accountID()
+		if seen[acctID] {
+			continue
+		}
+		seen[acctID] = true
+		res, err := endpointUserResource(inst, resolveIdentity(idIndex, inst.det.UserName))
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build endpoint_user resource: %w", err)
+		}
+		rv = append(rv, res)
+	}
+	return rv, &rs.SyncOpResults{}, nil
+}
+
+func (e *endpointUserResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (e *endpointUserResourceType) Grants(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// endpointUserResource builds a user-trait account for an endpoint OS user. When the
+// user resolves to an Identity Protection entity, its email is attached so c1 can
+// auto-match; otherwise the account stays unmatched for manual assignment.
+func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+	profile := map[string]interface{}{
+		"endpoint_user": d.UserName,
+		"host":          d.Hostname,
+		"aid":           d.AID,
+		"local_ip":      d.LocalIP,
+	}
+	displayName := fmt.Sprintf("%s@%s", d.UserName, d.Hostname)
+	traitOpts := []rs.UserTraitOption{rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED)}
+	if id != nil {
+		if id.displayName != "" {
+			displayName = fmt.Sprintf("%s (%s@%s)", id.displayName, d.UserName, d.Hostname)
+		}
+		profile["resolved_identity"] = id.displayName
+		profile["identity_external_id"] = id.externalID
+		if id.email != "" {
+			traitOpts = append(traitOpts, rs.WithEmail(id.email, true))
+		}
+	}
+	traitOpts = append(traitOpts, rs.WithUserProfile(profile))
+	return rs.NewUserResource(displayName, resourceTypeEndpointUser, inst.accountID(), traitOpts)
+}
+
+// buildIdentityIndex fetches all Identity Protection entities and indexes them by
+// lowercased samAccountName and email local-part for endpoint-user resolution.
+//
+// Endpoint usernames are ambiguous: two distinct identities can share a samAccountName
+// or email local-part. Rather than silently letting the last one win (which would pin a
+// shadow-MCP finding on the wrong person), a key that maps to more than one identity is
+// marked ambiguous (nil) and resolves to no match.
+func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, error) {
+	index := map[string]*resolvedIdentity{}
+	// insert records key->ri, but collapses to nil (ambiguous) if the key already
+	// resolves to a different identity.
+	insert := func(key string, ri *resolvedIdentity) {
+		key = strings.ToLower(key)
+		if key == "" {
+			return
+		}
+		existing, seen := index[key]
+		if !seen {
+			index[key] = ri
+			return
+		}
+		if existing == nil {
+			return // already ambiguous
+		}
+		if existing.externalID != ri.externalID {
+			index[key] = nil // collision between distinct identities
+		}
+	}
+	cursor := ""
+	for {
+		identities, next, hasNext, _, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for i := range identities {
+			id := identities[i]
+			email := ""
+			if len(id.EmailAddresses) > 0 {
+				email = id.EmailAddresses[0]
+			} else if validateEmail(id.SecondaryDisplayName) {
+				email = id.SecondaryDisplayName
+			}
+			for _, acct := range id.Accounts {
+				if acct.SamAccountName != "" {
+					insert(acct.SamAccountName, &resolvedIdentity{email: email, externalID: acct.ExternalID(), displayName: id.PrimaryDisplayName})
+				}
+			}
+			if email != "" {
+				if local := strings.SplitN(email, "@", 2)[0]; local != "" {
+					insert(local, &resolvedIdentity{email: email, externalID: firstExternalID(id), displayName: id.PrimaryDisplayName})
+				}
+			}
+		}
+		if !hasNext || next == "" {
+			break
+		}
+		cursor = next
+	}
+	return index, nil
+}
+
+func firstExternalID(id IdentityRiskData) string {
+	for _, acct := range id.Accounts {
+		if ext := acct.ExternalID(); ext != "" {
+			return ext
+		}
+	}
+	return ""
+}
+
+// resolveIdentity maps an endpoint OS username to an identity via samAccountName or email local-part.
+func resolveIdentity(index map[string]*resolvedIdentity, userName string) *resolvedIdentity {
+	if userName == "" {
+		return nil
+	}
+	if ri, ok := index[strings.ToLower(userName)]; ok {
+		return ri
+	}
+	return nil
+}
+
+// parseMCPServer extracts the MCP server identity from a process command line.
+func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok bool) {
+	match := mcpSignature.FindString(cmdline)
+	if match == "" {
+		return "", "", "", "", false
+	}
+	// A bare .js entrypoint (e.g. mcp-server-fetch.js) and its package name are the same
+	// logical server; drop the extension so they don't split into two resources.
+	match = strings.TrimSuffix(match, ".js")
+	pkg = match
+	// Derive a short logical name from the package suffix.
+	switch {
+	case strings.HasPrefix(match, "@modelcontextprotocol/server-"):
+		name = strings.TrimPrefix(match, "@modelcontextprotocol/server-")
+	case strings.HasPrefix(match, "mcp-server-"):
+		name = strings.TrimPrefix(match, "mcp-server-")
+	case strings.HasPrefix(match, "mcp_server_"):
+		name = strings.TrimPrefix(match, "mcp_server_")
+	default:
+		name = match
+	}
+
+	lc := strings.ToLower(cmdline)
+	switch {
+	case strings.Contains(lc, "npx"):
+		launcher = "npx"
+	case strings.Contains(lc, "uvx"):
+		launcher = "uvx"
+	case strings.Contains(lc, "python"):
+		launcher = "python"
+	case strings.Contains(lc, "node"):
+		launcher = "node"
+	default:
+		launcher = "unknown"
+	}
+
+	transport = "stdio"
+	if strings.Contains(lc, "--sse") || strings.Contains(lc, "transport sse") || strings.Contains(lc, "--port") {
+		transport = "sse/http"
+	}
+	return name, pkg, launcher, transport, true
+}
+
+// ---- Alerts API client (shadow-MCP detections) ----
+
+// mcpAlertMaxPages bounds how many pages of epp alerts we scan on very large tenants.
+// Each page holds up to mcpServerAlertLimit alerts.
+const mcpAlertMaxPages = 20
+
+type mcpDetectionsClient struct {
+	httpClient *http.Client
+	host       string
+}
+
+func newMCPDetectionsClient(ctx context.Context, clientID, clientSecret, host string) *mcpDetectionsClient {
+	config := clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     "https://" + host + "/oauth2/token",
+	}
+	httpClient := config.Client(ctx)
+	httpClient.Timeout = 30 * time.Second
+	return &mcpDetectionsClient{httpClient: httpClient, host: host}
+}
+
+type alertsQueryResp struct {
+	Resources []string `json:"resources"`
+}
+
+type alertsEntitiesResp struct {
+	Resources []struct {
+		Product     string `json:"product"`
+		UserName    string `json:"user_name"`
+		Cmdline     string `json:"cmdline"`
+		Filepath    string `json:"filepath"`
+		Timestamp   string `json:"timestamp"`
+		CompositeID string `json:"composite_id"`
+		FalconHost  string `json:"falcon_host_link"`
+		PatternName string `json:"name"`
+		Device      struct {
+			Hostname string `json:"hostname"`
+			DeviceID string `json:"device_id"`
+			LocalIP  string `json:"local_ip"`
+		} `json:"device"`
+	} `json:"resources"`
+}
+
+func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body string) ([]byte, error) {
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "baton-crowdstrike")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
+	}
+	return b, nil
+}
+
+// fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL
+// product filter, paginating to exhaustion (bounded by mcpAlertMaxPages), then keeps
+// the ones whose command line matches the MCP signature. Detections missing an AID or
+// user name are dropped — they cannot be attributed to a host or identity.
+func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, error) {
+	filter := url.QueryEscape("product:'epp'")
+	var ids []string
+	truncated := false
+	for page := 0; ; page++ {
+		if page >= mcpAlertMaxPages {
+			truncated = true
+			break
+		}
+		qURL := fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
+			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit)
+		b, err := c.doJSON(ctx, http.MethodGet, qURL, "")
+		if err != nil {
+			return nil, err
+		}
+		var q alertsQueryResp
+		if err := json.Unmarshal(b, &q); err != nil {
+			return nil, err
+		}
+		ids = append(ids, q.Resources...)
+		if len(q.Resources) < mcpServerAlertLimit {
+			break
+		}
+	}
+	if truncated {
+		ctxzap.Extract(ctx).Warn("baton-crowdstrike: mcp detection scan hit page cap; older epp alerts not scanned",
+			zap.Int("scanned_alerts", len(ids)), zap.Int("page_cap", mcpAlertMaxPages))
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var out []mcpDetection
+	for start := 0; start < len(ids); start += mcpServerAlertLimit {
+		end := start + mcpServerAlertLimit
+		if end > len(ids) {
+			end = len(ids)
+		}
+		detBody, _ := json.Marshal(map[string]interface{}{"composite_ids": ids[start:end]})
+		b, err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host), string(detBody))
+		if err != nil {
+			return nil, err
+		}
+		var e alertsEntitiesResp
+		if err := json.Unmarshal(b, &e); err != nil {
+			return nil, err
+		}
+		for _, a := range e.Resources {
+			if a.Product != "epp" || !mcpSignature.MatchString(a.Cmdline) {
+				continue
+			}
+			if a.Device.DeviceID == "" || a.UserName == "" {
+				continue // unattributable to a host/identity
+			}
+			ts, _ := time.Parse(time.RFC3339, a.Timestamp)
+			out = append(out, mcpDetection{
+				Hostname: a.Device.Hostname, AID: a.Device.DeviceID, LocalIP: a.Device.LocalIP,
+				UserName: a.UserName, CommandLine: a.Cmdline, FilePath: a.Filepath, Timestamp: ts,
+				CompositeID: a.CompositeID, FalconLink: a.FalconHost, IOARuleName: a.PatternName,
+			})
+		}
+	}
+	return out, nil
+}
+
+// mcpSource is a per-connector data source shared by the mcp_server and endpoint_user
+// syncers. It memoizes the detection snapshot and identity index per sync (keyed by
+// SyncID) so every List/Grants call across both resource types sees one consistent
+// snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
+// that independent re-fetches would cause. Only the current sync's data is retained.
+type mcpSource struct {
+	detClient *mcpDetectionsClient
+	ipClient  *IdentityProtectionClient
+
+	mu      sync.Mutex
+	detSync string
+	detData []mcpDetection
+	idxSync string
+	idxData map[string]*resolvedIdentity
+}
+
+func newMCPSource(ctx context.Context, clientID, clientSecret, host string) *mcpSource {
+	return &mcpSource{
+		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
+		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+	}
+}
+
+func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
+	s.mu.Lock()
+	if s.detData != nil && s.detSync == syncID {
+		d := s.detData
+		s.mu.Unlock()
+		return d, nil
+	}
+	s.mu.Unlock()
+	d, err := s.detClient.fetchAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.detSync, s.detData = syncID, d
+	s.mu.Unlock()
+	return d, nil
+}
+
+func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
+	s.mu.Lock()
+	if s.idxData != nil && s.idxSync == syncID {
+		idx := s.idxData
+		s.mu.Unlock()
+		return idx, nil
+	}
+	s.mu.Unlock()
+	idx, err := buildIdentityIndex(ctx, s.ipClient)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.idxSync, s.idxData = syncID, idx
+	s.mu.Unlock()
+	return idx, nil
+}
+
+func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {
+	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src}
+}
+
+func endpointUserBuilder(src *mcpSource) *endpointUserResourceType {
+	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src}
+}

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,10 +16,10 @@ import (
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 // mcpRunnerEntitlement is the assignment entitlement on an mcp_server resource held
@@ -479,18 +476,11 @@ func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 const mcpAlertMaxPages = 10
 
 type mcpDetectionsClient struct {
-	httpClient *http.Client
+	httpClient *uhttp.BaseHttpClient
 	host       string
 }
 
-func newMCPDetectionsClient(ctx context.Context, clientID, clientSecret, host string) *mcpDetectionsClient {
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
+func newMCPDetectionsClient(httpClient *uhttp.BaseHttpClient, host string) *mcpDetectionsClient {
 	return &mcpDetectionsClient{httpClient: httpClient, host: host}
 }
 
@@ -516,85 +506,6 @@ type alertsEntitiesResp struct {
 	} `json:"resources"`
 }
 
-// mcpMaxRetries is how many times doJSON retries a rate-limited (429) or transient
-// server (5xx) response before giving up.
-const mcpMaxRetries = 4
-
-func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, reqURL, body string) ([]byte, error) {
-	var lastErr error
-	for attempt := 0; attempt <= mcpMaxRetries; attempt++ {
-		var rdr io.Reader
-		if body != "" {
-			rdr = strings.NewReader(body)
-		}
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, rdr)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", "baton-crowdstrike")
-		if body != "" {
-			req.Header.Set("Content-Type", "application/json")
-		}
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			// Transient transport error — retry with backoff.
-			lastErr = err
-			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, 0) {
-				continue
-			}
-			return nil, err
-		}
-		b, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-
-		if resp.StatusCode == http.StatusOK {
-			return b, nil
-		}
-		// Retry on rate limiting and transient server errors, honoring Retry-After.
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
-			lastErr = fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
-			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, retryAfterSeconds(resp.Header)) {
-				continue
-			}
-			return nil, lastErr
-		}
-		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
-	}
-	return nil, lastErr
-}
-
-// retryAfterSeconds reads a Retry-After header expressed in seconds; 0 if absent/invalid.
-func retryAfterSeconds(h http.Header) int {
-	if v := h.Get("Retry-After"); v != "" {
-		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
-			return n
-		}
-	}
-	return 0
-}
-
-// waitBackoff sleeps before a retry — the larger of Retry-After and an exponential
-// backoff (1s, 2s, 4s, ... capped at 30s). Returns false if the context is cancelled.
-func waitBackoff(ctx context.Context, attempt, retryAfter int) bool {
-	backoff := time.Duration(1<<attempt) * time.Second
-	if backoff > 30*time.Second {
-		backoff = 30 * time.Second
-	}
-	if ra := time.Duration(retryAfter) * time.Second; ra > backoff {
-		backoff = ra
-	}
-	t := time.NewTimer(backoff)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-t.C:
-		return true
-	}
-}
-
 // fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL
 // product filter, paginating to exhaustion (bounded by mcpAlertMaxPages), then keeps
 // the ones whose command line matches the MCP signature. Detections missing an AID or
@@ -608,14 +519,21 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			truncated = true
 			break
 		}
-		qURL := fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
-			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit)
-		b, err := c.doJSON(ctx, http.MethodGet, qURL, "")
+		qURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
+			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit))
+		if err != nil {
+			return nil, err
+		}
+		req, err := c.httpClient.NewRequest(ctx, http.MethodGet, qURL, uhttp.WithAcceptJSONHeader())
 		if err != nil {
 			return nil, err
 		}
 		var q alertsQueryResp
-		if err := json.Unmarshal(b, &q); err != nil {
+		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&q))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err != nil {
 			return nil, err
 		}
 		ids = append(ids, q.Resources...)
@@ -631,19 +549,28 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 		return nil, nil
 	}
 
+	entitiesURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host))
+	if err != nil {
+		return nil, err
+	}
+
 	var out []mcpDetection
 	for start := 0; start < len(ids); start += mcpServerAlertLimit {
 		end := start + mcpServerAlertLimit
 		if end > len(ids) {
 			end = len(ids)
 		}
-		detBody, _ := json.Marshal(map[string]interface{}{"composite_ids": ids[start:end]})
-		b, err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host), string(detBody))
+		req, err := c.httpClient.NewRequest(ctx, http.MethodPost, entitiesURL,
+			uhttp.WithJSONBody(map[string]interface{}{"composite_ids": ids[start:end]}), uhttp.WithAcceptJSONHeader())
 		if err != nil {
 			return nil, err
 		}
 		var e alertsEntitiesResp
-		if err := json.Unmarshal(b, &e); err != nil {
+		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&e))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err != nil {
 			return nil, err
 		}
 		for _, a := range e.Resources {
@@ -685,11 +612,11 @@ type mcpSource struct {
 	idxData map[string]*resolvedIdentity
 }
 
-func newMCPSource(ctx context.Context, clientID, clientSecret, host string, enabled bool) *mcpSource {
+func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *mcpSource {
 	return &mcpSource{
 		enabled:   enabled,
-		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
-		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		detClient: newMCPDetectionsClient(httpClient, host),
+		ipClient:  NewIdentityProtectionClient(httpClient, host),
 	}
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -527,7 +527,6 @@ func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body stri
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	//nolint:gosec // url is built from the connector's configured CrowdStrike region host, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -472,8 +473,10 @@ func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 // ---- Alerts API client (shadow-MCP detections) ----
 
 // mcpAlertMaxPages bounds how many pages of epp alerts we scan on very large tenants.
-// Each page holds up to mcpServerAlertLimit alerts.
-const mcpAlertMaxPages = 20
+// Each page holds up to mcpServerAlertLimit alerts. Capped at 10 so the largest offset
+// stays below CrowdStrike's ~10,000-record deep-pagination limit on the alerts query
+// endpoint (a request at offset >= 10000 is rejected).
+const mcpAlertMaxPages = 10
 
 type mcpDetectionsClient struct {
 	httpClient *http.Client
@@ -513,30 +516,83 @@ type alertsEntitiesResp struct {
 	} `json:"resources"`
 }
 
-func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body string) ([]byte, error) {
-	var rdr io.Reader
-	if body != "" {
-		rdr = strings.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "baton-crowdstrike")
-	if body != "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
+// mcpMaxRetries is how many times doJSON retries a rate-limited (429) or transient
+// server (5xx) response before giving up.
+const mcpMaxRetries = 4
+
+func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, reqURL, body string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= mcpMaxRetries; attempt++ {
+		var rdr io.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, rdr)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "baton-crowdstrike")
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			// Transient transport error — retry with backoff.
+			lastErr = err
+			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, 0) {
+				continue
+			}
+			return nil, err
+		}
+		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			return b, nil
+		}
+		// Retry on rate limiting and transient server errors, honoring Retry-After.
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+			lastErr = fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
+			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, retryAfterSeconds(resp.Header)) {
+				continue
+			}
+			return nil, lastErr
+		}
 		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
 	}
-	return b, nil
+	return nil, lastErr
+}
+
+// retryAfterSeconds reads a Retry-After header expressed in seconds; 0 if absent/invalid.
+func retryAfterSeconds(h http.Header) int {
+	if v := h.Get("Retry-After"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// waitBackoff sleeps before a retry — the larger of Retry-After and an exponential
+// backoff (1s, 2s, 4s, ... capped at 30s). Returns false if the context is cancelled.
+func waitBackoff(ctx context.Context, attempt, retryAfter int) bool {
+	backoff := time.Duration(1<<attempt) * time.Second
+	if backoff > 30*time.Second {
+		backoff = 30 * time.Second
+	}
+	if ra := time.Duration(retryAfter) * time.Second; ra > backoff {
+		backoff = ra
+	}
+	t := time.NewTimer(backoff)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -614,11 +614,17 @@ type mcpSource struct {
 	detClient *mcpDetectionsClient
 	ipClient  *IdentityProtectionClient
 
-	mu      sync.Mutex
-	detSync string
-	detData []mcpDetection
-	idxSync string
-	idxData map[string]*resolvedIdentity
+	mu sync.Mutex
+	// detFetched/idxFetched track whether the current sync's fetch has run, so an
+	// empty result still caches (a nil/empty slice or map is a valid cached value —
+	// gating on the data being non-nil would re-scan every caller when a sync finds
+	// nothing). detSync/idxSync scope the cache to a single sync.
+	detFetched bool
+	detSync    string
+	detData    []mcpDetection
+	idxFetched bool
+	idxSync    string
+	idxData    map[string]*resolvedIdentity
 }
 
 func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *mcpSource {
@@ -640,14 +646,14 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 	// sequentially, never nested, so there is no lock-ordering hazard.)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.detData != nil && s.detSync == syncID {
+	if s.detFetched && s.detSync == syncID {
 		return s.detData, nil
 	}
 	d, err := s.detClient.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	s.detSync, s.detData = syncID, d
+	s.detFetched, s.detSync, s.detData = true, syncID, d
 	return d, nil
 }
 
@@ -658,14 +664,14 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.idxData != nil && s.idxSync == syncID {
+	if s.idxFetched && s.idxSync == syncID {
 		return s.idxData, nil
 	}
 	idx, err := buildIdentityIndex(ctx, s.ipClient)
 	if err != nil {
 		return nil, err
 	}
-	s.idxSync, s.idxData = syncID, idx
+	s.idxFetched, s.idxSync, s.idxData = true, syncID, idx
 	return idx, nil
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -349,6 +349,11 @@ func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Re
 // or email local-part. Rather than silently letting the last one win (which would pin a
 // shadow-MCP finding on the wrong person), a key that maps to more than one identity is
 // marked ambiguous (nil) and resolves to no match.
+// mcpIdentityIndexMaxPages bounds the Identity Protection entity pages scanned when
+// building the endpoint-user→identity resolution index, so a very large tenant can't
+// turn a single sync into an unbounded sequence of sequential GraphQL round trips.
+const mcpIdentityIndexMaxPages = 100
+
 func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, error) {
 	index := map[string]*resolvedIdentity{}
 	// insert records key->ri, but collapses to nil (ambiguous) if the key already
@@ -371,7 +376,7 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 		}
 	}
 	cursor := ""
-	for {
+	for page := 0; page < mcpIdentityIndexMaxPages; page++ {
 		identities, next, hasNext, _, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
 		if err != nil {
 			return nil, err
@@ -396,10 +401,14 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 			}
 		}
 		if !hasNext || next == "" {
-			break
+			return index, nil
 		}
 		cursor = next
 	}
+	// Page cap reached with more identities remaining: the index is partial this sync,
+	// so some endpoint users may not resolve to an identity.
+	ctxzap.Extract(ctx).Warn("baton-crowdstrike: identity index hit page cap; not all identities indexed",
+		zap.Int("page_cap", mcpIdentityIndexMaxPages), zap.Int("indexed_keys", len(index)))
 	return index, nil
 }
 
@@ -624,20 +633,21 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 	if !s.enabled {
 		return nil, nil
 	}
+	// Hold the lock across the fetch so the mcp_server and endpoint_user syncers —
+	// which run in parallel and share this source — perform exactly ONE Alerts scan
+	// per sync: the first caller fetches while the sibling blocks, then both see the
+	// same cached snapshot. (The two syncers call detections/identityIndex
+	// sequentially, never nested, so there is no lock-ordering hazard.)
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.detData != nil && s.detSync == syncID {
-		d := s.detData
-		s.mu.Unlock()
-		return d, nil
+		return s.detData, nil
 	}
-	s.mu.Unlock()
 	d, err := s.detClient.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
 	s.detSync, s.detData = syncID, d
-	s.mu.Unlock()
 	return d, nil
 }
 
@@ -645,20 +655,17 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	if !s.enabled {
 		return map[string]*resolvedIdentity{}, nil
 	}
+	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.idxData != nil && s.idxSync == syncID {
-		idx := s.idxData
-		s.mu.Unlock()
-		return idx, nil
+		return s.idxData, nil
 	}
-	s.mu.Unlock()
 	idx, err := buildIdentityIndex(ctx, s.ipClient)
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
 	s.idxSync, s.idxData = syncID, idx
-	s.mu.Unlock()
 	return idx, nil
 }
 

--- a/pkg/connector/mcp_server_test.go
+++ b/pkg/connector/mcp_server_test.go
@@ -1,0 +1,129 @@
+package connector
+
+import "testing"
+
+func TestParseMCPServer(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmdline    string
+		wantName   string
+		wantPkg    string
+		wantLaunch string
+		wantOK     bool
+	}{
+		{
+			name:       "npx scoped server",
+			cmdline:    "npx -y @modelcontextprotocol/server-filesystem /tmp",
+			wantName:   "filesystem",
+			wantPkg:    "@modelcontextprotocol/server-filesystem",
+			wantLaunch: "npx",
+			wantOK:     true,
+		},
+		{
+			// An npx-cached path contains "_npx", so npx provenance is reported.
+			name:       "node bin from npx cache resolves as npx",
+			cmdline:    "node /home/u/.npm/_npx/abc/node_modules/.bin/mcp-server-everything",
+			wantName:   "everything",
+			wantPkg:    "mcp-server-everything",
+			wantLaunch: "npx",
+			wantOK:     true,
+		},
+		{
+			name:       "pure node invocation",
+			cmdline:    "node /opt/mcp/bin/mcp-server-fetch",
+			wantName:   "fetch",
+			wantPkg:    "mcp-server-fetch",
+			wantLaunch: "node",
+			wantOK:     true,
+		},
+		{
+			// A bare .js entrypoint normalizes to the same name/pkg as the package form.
+			name:       "js entrypoint normalizes",
+			cmdline:    "node /opt/mcp/dist/mcp-server-fetch.js",
+			wantName:   "fetch",
+			wantPkg:    "mcp-server-fetch",
+			wantLaunch: "node",
+			wantOK:     true,
+		},
+		{
+			name:       "uvx python server",
+			cmdline:    "uvx mcp-server-time",
+			wantName:   "time",
+			wantPkg:    "mcp-server-time",
+			wantLaunch: "uvx",
+			wantOK:     true,
+		},
+		{
+			name:       "python module underscore package",
+			cmdline:    "python -m mcp_server_git",
+			wantName:   "git",
+			wantPkg:    "mcp_server_git",
+			wantLaunch: "python",
+			wantOK:     true,
+		},
+		{
+			name:       "shell wrapper without launcher token still matches",
+			cmdline:    "sh -c mcp-server-everything",
+			wantName:   "everything",
+			wantPkg:    "mcp-server-everything",
+			wantLaunch: "unknown",
+			wantOK:     true,
+		},
+		{
+			name:    "non-mcp process",
+			cmdline: "/usr/bin/bash -c ls -la /tmp",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, pkg, launcher, transport, ok := parseMCPServer(tt.cmdline)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if pkg != tt.wantPkg {
+				t.Errorf("pkg = %q, want %q", pkg, tt.wantPkg)
+			}
+			if launcher != tt.wantLaunch {
+				t.Errorf("launcher = %q, want %q", launcher, tt.wantLaunch)
+			}
+			if transport != "stdio" {
+				t.Errorf("transport = %q, want stdio", transport)
+			}
+		})
+	}
+}
+
+func TestParseMCPServerSSETransport(t *testing.T) {
+	_, _, _, transport, ok := parseMCPServer("node server.js mcp-server-fetch --sse --port 8080")
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if transport != "sse/http" {
+		t.Errorf("transport = %q, want sse/http", transport)
+	}
+}
+
+func TestResolveIdentityAmbiguous(t *testing.T) {
+	index := map[string]*resolvedIdentity{
+		"ambig":  nil, // ambiguous: two identities shared this samAccountName
+		"asmith": {email: "asmith@example.com", externalID: "ext-1", displayName: "A. Smith"},
+	}
+	if got := resolveIdentity(index, "ambig"); got != nil {
+		t.Errorf("ambiguous key resolved to %v, want nil", got)
+	}
+	if got := resolveIdentity(index, "unknown"); got != nil {
+		t.Errorf("unknown key resolved to %v, want nil", got)
+	}
+	got := resolveIdentity(index, "ASmith") // case-insensitive
+	if got == nil || got.externalID != "ext-1" {
+		t.Errorf("expected A. Smith (ext-1), got %v", got)
+	}
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -57,4 +57,40 @@ var (
 			),
 		),
 	}
+	// resourceTypeMCPServer models an unsanctioned ("shadow") Model Context Protocol
+	// server observed running on an endpoint via CrowdStrike EDR detections. It carries
+	// a full App-trait profile (server, endpoint, and resolved-identity metadata) and a
+	// security-insight annotation binding the finding to the identity's c1 risk.
+	resourceTypeMCPServer = &v2.ResourceType{
+		Id:          "mcp_server",
+		DisplayName: "Shadow MCP Server",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_APP,
+			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+				"Identity Protection GraphQL: Write",
+			),
+		),
+	}
+	// resourceTypeEndpointUser is the endpoint OS user that ran a shadow MCP server,
+	// modeled as an app account so it can be assigned to a ConductorOne identity and
+	// shown against the mcp_server resources it ran (grant principal only).
+	resourceTypeEndpointUser = &v2.ResourceType{
+		Id:          "endpoint_user",
+		DisplayName: "Endpoint User",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_USER,
+		},
+		Annotations: annotations.New(
+			&v2.SkipEntitlementsAndGrants{},
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+			),
+		),
+	}
 )

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -21,8 +21,8 @@ type securityInsightResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	ipClient     *IdentityProtectionClient
-	// enabled gates risk-score ingestion. When false (the default), List is a no-op
-	// that makes no Identity Protection API call — the capability is opt-in.
+	// enabled gates risk-score ingestion (on by default). When false, List is a
+	// no-op that makes no Identity Protection API call.
 	enabled bool
 }
 
@@ -103,8 +103,8 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 }
 
 func (s *securityInsightResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	// Opt-in: when risk-score ingestion is disabled, sync nothing and make no
-	// Identity Protection API call.
+	// When risk-score ingestion is disabled, sync nothing and make no Identity
+	// Protection API call.
 	if !s.enabled {
 		return nil, &rs.SyncOpResults{}, nil
 	}

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -21,6 +21,9 @@ type securityInsightResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	ipClient     *IdentityProtectionClient
+	// enabled gates risk-score ingestion. When false (the default), List is a no-op
+	// that makes no Identity Protection API call — the capability is opt-in.
+	enabled bool
 }
 
 func (s *securityInsightResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -100,6 +103,12 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 }
 
 func (s *securityInsightResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	// Opt-in: when risk-score ingestion is disabled, sync nothing and make no
+	// Identity Protection API call.
+	if !s.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+
 	// Parse the page token to get the cursor
 	cursor := opts.PageToken.Token
 
@@ -174,10 +183,11 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string) *securityInsightResourceType {
+func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string, enabled bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
 		ipClient:     NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		enabled:      enabled,
 	}
 }

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -9,6 +9,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
 )
 
@@ -183,11 +184,11 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string, enabled bool) *securityInsightResourceType {
+func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, enabled bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
-		ipClient:     NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		ipClient:     NewIdentityProtectionClient(httpClient, host),
 		enabled:      enabled,
 	}
 }


### PR DESCRIPTION
## What

Adds shadow-MCP-server discovery to `baton-crowdstrike`. It reads CrowdStrike EDR detections, identifies unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers by command-line signature (`@modelcontextprotocol/server-*`, `mcp-server-*`, `mcp_server_*`), and models them in ConductorOne so a shadow MCP shows up against a real person in access reviews:

- **`mcp_server`** (App trait) — one per deduped (host, user, server). Profile carries server/endpoint/identity metadata (`server_name`, `package`, `launcher`, `transport`, `host`, `aid`, `local_ip`, `endpoint_user`, `sample_command_line`, `detection_count`, `ioa_rule`, `falcon_link`, `sanctioned`, `first_seen`, and `identity_*` when resolved), plus a security-insight issue bound to the resolved identity.
- **`endpoint_user`** (User trait) — the OS user that ran the server, as an app account; auto-matched to a c1 identity by email when it resolves in Identity Protection, otherwise assignable manually.
- **`runner`** assignment entitlement on each `mcp_server`, granted to the `endpoint_user` account.

Result: a **c1 identity → `endpoint_user` account → `runner` grant → `mcp_server`** chain.

## How

- Reads detections from the **Alerts API**, narrowed server-side by an FQL `product:'epp'` filter and paginated to exhaustion (bounded, logs if capped); matches the MCP signature client-side.
- Resolves the endpoint OS user to an Identity Protection entity via `samAccountName` / email local-part.
- The `mcp_server` and `endpoint_user` syncers share one per-sync (SyncID-keyed) detection snapshot + identity index, so grants are consistent and Alerts/Identity-Protection aren't re-queried per resource.

## Scopes

Adds **Alerts: Read** (documented in the README). Correlation reuses the existing Identity Protection scopes.

## Detecting the servers

CrowdStrike raises the detections this connector reads via a **Custom IOA** Process-Creation rule (Detect disposition) matching the signature; documented in the README. MCP servers are benign to default detections, so this rule is the prerequisite for any findings.

## Testing

- Unit tests for the command-line parser (`parseMCPServer`) and the ambiguous-identity guard (`resolveIdentity`).
- Validated live against a test tenant end to end: a Falcon-sensored endpoint running real MCP servers produced native EDR detections, which this connector synced into a ConductorOne tenant as `mcp_server` resources + `endpoint_user` accounts + `runner` grants, with each server correlated to the identity of the OS user that ran it.

## Notes

Hardened after an adversarial review: server-side-filtered + paginated detection fetch (was newest-1000-only), shared per-sync snapshot (removes per-resource re-fetch and grant drift), stable resource IDs derived from the deduped server name, ambiguous identity matches resolve to no identity (avoids attributing a finding to the wrong person), and unattributable detections (missing AID/user) are dropped.

Opened as a **draft**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

