### PR TITLE
feat(crowdstrike): detect AI coding tools on endpoints (opt-in)

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -3,6 +3,48 @@
   "resourceTypeCapabilities": [
     {
       "resourceType": {
+        "id": "ai_tool",
+        "displayName": "AI Coding Tool",
+        "traits": [
+          "TRAIT_APP",
+          "TRAIT_SECURITY_INSIGHT"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              },
+              {
+                "permission": "Identity Protection GraphQL: Write"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          },
+          {
+            "permission": "Identity Protection GraphQL: Write"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
         "id": "endpoint_user",
         "displayName": "Endpoint User",
         "traits": [

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -11,6 +11,9 @@
         ],
         "annotations": [
           {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {

--- a/config_schema.json
+++ b/config_schema.json
@@ -144,6 +144,12 @@
       "displayName": "Detect shadow MCP servers",
       "description": "Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint users that ran them, correlated to identities. Off by default; requires the Alerts read scope.",
       "boolField": {}
+    },
+    {
+      "name": "crowdstrike-detect-ai-tools",
+      "displayName": "Detect AI coding tools",
+      "description": "Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the Alerts read scope.",
+      "boolField": {}
     }
   ],
   "displayName": "CrowdStrike",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -15,6 +15,7 @@ sidebarTitle: "CrowdStrike"
 | Insights | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| AI coding tools (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
 ### Connector actions
 
@@ -350,3 +351,56 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
 In C1, open the connector's **Settings** and enable **Detect shadow MCP servers** (off by default), then save.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.
+
+## Detect AI coding tools
+
+<Warning>
+**Early access.** This feature is in early access, which means it's undergoing ongoing testing and development while we gather feedback, validate functionality, and improve outputs. Contact the C1 Support team if you'd like to try it out or share feedback.
+</Warning>
+
+The CrowdStrike connector can inventory **AI coding tools** ("harnesses" — Claude Code, Claude Desktop, Cursor, Windsurf, OpenAI Codex, Gemini CLI, GitHub Copilot CLI, opencode, Aider, and similar) observed running on your endpoints, and correlate each to the identity that ran it. This gives you governance visibility into which people are using which AI tools on which hosts. It reads CrowdStrike endpoint detections and models each tool as an **`ai_tool`** resource describing the tool (name, vendor, category, host, sample command line, and the identity it resolved to), with a low-severity insight linking it to that identity.
+
+This shares the same detection pipeline as shadow MCP detection — it reads the Alerts API and resolves endpoint users to identities the same way — but is turned on and off independently.
+
+### Before you begin
+
+Confirm that:
+
+- Your CrowdStrike environment generates endpoint detections (the connector reads them via the Alerts API)
+- You have the **Falcon Administrator** role in CrowdStrike
+- Your CrowdStrike connector is already set up and syncing in C1
+
+### Add the required API scope
+
+The **Alerts: Read** scope is required (the same scope shadow MCP detection uses). Keep **Identity Protection Entities: Read** enabled so AI-tool usage can be matched to identities. If you already enabled these for shadow MCP detection, no change is needed.
+
+### Create a detection rule for AI coding tools
+
+CrowdStrike doesn't flag AI coding tools by default, so you author a Custom IOA rule that raises a detection the connector can read.
+
+<Steps>
+  <Step>
+  In the Falcon console, create or open a **Custom IOA rule group** for each platform you want to cover (Windows, macOS, Linux).
+  </Step>
+  <Step>
+  Add a **Process Creation** rule with the **Detect** disposition.
+  </Step>
+  <Step>
+  Set the rule's **Command Line** field to match common AI coding tools:
+
+  ```
+  (?i).*(claude-code|[\\/]claude\.(exe|app)|[\\/]cursor\.(exe|app)|cursor-agent|[\\/]windsurf|@openai[\\/]codex|codex-cli|@github[\\/]copilot|copilot-cli|gemini-cli|[\\/]opencode|[\\/]aider).*
+  ```
+
+  Adjust the list to the tools you want to track. The pattern anchors tool names to executables and package paths (rather than matching the bare words "codex" or "copilot" anywhere) to avoid raising detections on unrelated software. Because AI coding tools are ordinary developer software rather than threats, expect a detection each time one launches.
+  </Step>
+  <Step>
+  Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
+  </Step>
+</Steps>
+
+### Turn on AI coding tool detection
+
+In C1, open the connector's **Settings** and enable **Detect AI coding tools** (off by default), then save.
+
+**Done.** As endpoints run AI coding tools, CrowdStrike raises detections and the connector syncs them into C1 as `ai_tool` resources correlated to the identities that ran them.

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Crowdstrike struct {
 	BaseUrl string `mapstructure:"base-url"`
 	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
 	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
+	CrowdstrikeDetectAiTools bool `mapstructure:"crowdstrike-detect-ai-tools"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,14 @@ var (
 			"users that ran them, correlated to identities. Off by default; requires the Alerts read scope."),
 		field.WithDefaultValue(false),
 	)
+	DetectAIToolsField = field.BoolField(
+		"crowdstrike-detect-ai-tools",
+		field.WithDisplayName("Detect AI coding tools"),
+		field.WithDescription("Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and "+
+			"similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the "+
+			"Alerts read scope."),
+		field.WithDefaultValue(false),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
@@ -55,6 +63,7 @@ var (
 		BaseURLField,
 		IngestRiskScoresField,
 		DetectShadowMCPField,
+		DetectAIToolsField,
 	}
 )
 

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -36,16 +36,35 @@ type harnessEntry struct {
 // package names (@vendor/tool) or path-qualified executables rather than bare words, to
 // keep common English tokens (e.g. "gemini", "copilot") from matching unrelated
 // processes. This is not meant to be exhaustive — it covers the popular harnesses.
+// cmdToken matches a bare CLI name only where a real invocation puts it: at the start
+// of the command line, right after a path separator (an installed binary), or after a
+// "-m " / "-m=" Python module flag — and only when it ends the token (end-of-string or
+// whitespace/quote). This deliberately rejects the name appearing mid-prose ("run the
+// codex"), as a substring of a longer word, or as a file with an extension
+// ("aider.sh", "Copilot.exe"), which is where bare \bword\b matching produces false
+// positives. %s is the tool name (already regex-safe here).
+func cmdToken(name string) string {
+	return `(^|[\\/]|-m[= ])` + name + `($|[\s"'])`
+}
+
 var harnessCatalog = []harnessEntry{
+	// Claude Code always runs as node against its package path, so match that (works on
+	// every OS); listed before Claude Desktop so the CLI never falls through to it.
 	{"Claude Code", "Anthropic", harnessKindCLI, regexp.MustCompile(`(?i)(@anthropic-ai[\\/]claude-code|claude-code)`)},
-	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|[\\/]claude\.exe)`)},
-	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|cursor-agent|[\\/]cursor-tunnel)`)},
-	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.exe|\bwindsurf\b)`)},
-	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|[\\/]codex\.(exe|cmd|js))`)},
+	// Claude Desktop: Windows AnthropicClaude\...\Claude.exe, macOS Claude.app bundle.
+	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|claude\.app|[\\/]claude\.exe)`)},
+	// Cursor / Windsurf: Windows .exe, macOS .app, plus Cursor's agent/tunnel CLIs. Bare
+	// "cursor" is intentionally NOT matched (collides with SQL cursors); Windsurf's name
+	// is distinctive enough to token-match its bare binary (Linux AppImage).
+	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|[\\/]cursor\.app|cursor-agent|[\\/]cursor-tunnel)`)},
+	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.(exe|app)|` + cmdToken("windsurf") + `)`)},
+	// CLIs: match the npm scope/package form AND the bare installed binary (Homebrew /
+	// curl installs invoke it as just "codex", "copilot", etc.).
+	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|` + cmdToken("codex") + `)`)},
 	{"Gemini CLI", "Google", harnessKindCLI, regexp.MustCompile(`(?i)(@google[\\/]gemini-cli|gemini-cli)`)},
-	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli)`)},
-	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)\bopencode\b`)},
-	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)\baider\b`)},
+	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli|` + cmdToken("copilot") + `)`)},
+	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)` + cmdToken("opencode"))},
+	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)` + cmdToken("aider"))},
 }
 
 // classifyHarness returns the AI tool a command line belongs to, or nil if none match.

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -1,0 +1,232 @@
+package connector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// AI coding tool ("harness") categories.
+const (
+	harnessKindCLI     = "cli"     // terminal agent (Claude Code, codex, aider, …)
+	harnessKindDesktop = "desktop" // standalone desktop app (Claude Desktop)
+	harnessKindIDE     = "ide"     // AI-native editor (Cursor, Windsurf)
+)
+
+// harnessEntry describes one recognizable AI coding tool and the command-line pattern
+// that identifies it. The pattern is matched against process-creation command lines
+// surfaced by the Alerts API (the same shared scan shadow-MCP detection reads).
+type harnessEntry struct {
+	name    string
+	vendor  string
+	kind    string
+	pattern *regexp.Regexp
+}
+
+// harnessCatalog is the ordered list of AI coding tools we recognize. Order matters:
+// classifyHarness returns the first match, so more specific tools come before broader
+// ones (e.g. Claude Code before Claude Desktop). Patterns are deliberately anchored on
+// package names (@vendor/tool) or path-qualified executables rather than bare words, to
+// keep common English tokens (e.g. "gemini", "copilot") from matching unrelated
+// processes. This is not meant to be exhaustive — it covers the popular harnesses.
+var harnessCatalog = []harnessEntry{
+	{"Claude Code", "Anthropic", harnessKindCLI, regexp.MustCompile(`(?i)(@anthropic-ai[\\/]claude-code|claude-code)`)},
+	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|[\\/]claude\.exe)`)},
+	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|cursor-agent|[\\/]cursor-tunnel)`)},
+	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.exe|\bwindsurf\b)`)},
+	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|[\\/]codex\.(exe|cmd|js))`)},
+	{"Gemini CLI", "Google", harnessKindCLI, regexp.MustCompile(`(?i)(@google[\\/]gemini-cli|gemini-cli)`)},
+	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli)`)},
+	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)\bopencode\b`)},
+	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)\baider\b`)},
+}
+
+// classifyHarness returns the AI tool a command line belongs to, or nil if none match.
+func classifyHarness(cmdline string) *harnessEntry {
+	for i := range harnessCatalog {
+		if harnessCatalog[i].pattern.MatchString(cmdline) {
+			return &harnessCatalog[i]
+		}
+	}
+	return nil
+}
+
+// matchesHarness reports whether a command line names a known AI coding tool. It is used
+// by the shared Alerts scan to keep harness detections alongside shadow-MCP ones.
+func matchesHarness(cmdline string) bool {
+	return classifyHarness(cmdline) != nil
+}
+
+// aiToolInstance is a deduplicated (host, user, tool) AI-tool observation. A tool
+// surfaces under many command-line spellings across the process tree; we collapse them
+// per logical tool and keep the earliest sighting plus the cleanest sample command line.
+type aiToolInstance struct {
+	det         mcpDetection
+	entry       *harnessEntry
+	bestCmdline string
+	count       int
+}
+
+// objectID is the stable ai_tool resource ID: sha256(aid|user|tool) — the same fields
+// buildAIToolInstances dedups on — so it is stable across syncs and command-line
+// spellings.
+func (inst *aiToolInstance) objectID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName), inst.entry.name}, "|")))
+	return "ai-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// buildAIToolInstances deduplicates harness detections into unique (host, user, tool)
+// instances, keeping the earliest timestamp and shortest sample command line.
+func buildAIToolInstances(dets []mcpDetection) map[string]*aiToolInstance {
+	instances := map[string]*aiToolInstance{}
+	for _, d := range dets {
+		if d.AID == "" || d.UserName == "" {
+			continue // unattributable — avoid collapsing distinct hosts/users into one id
+		}
+		entry := classifyHarness(d.CommandLine)
+		if entry == nil {
+			continue
+		}
+		key := strings.Join([]string{d.AID, strings.ToLower(d.UserName), entry.name}, "|")
+		inst, seen := instances[key]
+		if !seen {
+			instances[key] = &aiToolInstance{det: d, entry: entry, bestCmdline: d.CommandLine, count: 1}
+			continue
+		}
+		inst.count++
+		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
+			inst.det.Timestamp = d.Timestamp
+		}
+		if len(d.CommandLine) < len(inst.bestCmdline) {
+			inst.bestCmdline = d.CommandLine
+		}
+	}
+	return instances
+}
+
+// aiToolResourceType syncs AI coding tools ("harnesses" — Claude Code, Cursor, codex,
+// etc.) observed running on endpoints via CrowdStrike EDR detections, correlating each
+// to the identity that ran it. It is an inventory/governance signal (which identities
+// use which AI tools on which hosts), distinct from the shadow-MCP finding.
+type aiToolResourceType struct {
+	resourceType *v2.ResourceType
+	src          *mcpSource
+	// enabled gates AI-tool inventory. The shared source may still scan for shadow-MCP;
+	// this flag decides whether ai_tool resources are emitted.
+	enabled bool
+}
+
+func (a *aiToolResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return a.resourceType
+}
+
+// List scans the shared EDR detection snapshot for AI-tool activity, correlates each to
+// an identity, and returns one ai_tool resource per unique (host, user, tool).
+func (a *aiToolResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !a.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	dets, err := a.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	idIndex, err := a.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to build identity index: %w", err)
+	}
+
+	instances := buildAIToolInstances(dets)
+	resources := make([]*v2.Resource, 0, len(instances))
+	for _, inst := range instances {
+		res, err := aiToolResource(inst, resolveIdentity(idIndex, inst.det.UserName))
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build ai_tool resource: %w", err)
+		}
+		resources = append(resources, res)
+	}
+	return resources, &rs.SyncOpResults{}, nil
+}
+
+func (a *aiToolResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (a *aiToolResourceType) Grants(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// aiToolResource builds an ai_tool resource: an App-trait profile carrying the tool +
+// endpoint + resolved-identity metadata, plus a low-severity security-insight annotation
+// binding the observation to the identity (when one resolves) so it surfaces in c1's
+// identity view as governance visibility rather than a high-severity finding.
+func aiToolResource(inst *aiToolInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+	e := inst.entry
+
+	displayName := fmt.Sprintf("AI Tool: %s @ %s", e.name, d.Hostname)
+	if d.UserName != "" {
+		displayName = fmt.Sprintf("%s (%s)", displayName, d.UserName)
+	}
+
+	profile := map[string]interface{}{
+		"tool":                e.name,
+		"vendor":              e.vendor,
+		"kind":                e.kind,
+		"endpoint_user":       d.UserName,
+		"host":                d.Hostname,
+		"aid":                 d.AID,
+		"local_ip":            d.LocalIP,
+		"sample_command_line": inst.bestCmdline,
+		"detection_count":     inst.count,
+		"ioa_rule":            d.IOARuleName,
+		"falcon_link":         d.FalconLink,
+	}
+	if !d.Timestamp.IsZero() {
+		profile["first_seen"] = d.Timestamp.UTC().Format(time.RFC3339)
+	}
+	if id != nil {
+		profile["identity_email"] = id.email
+		profile["identity_external_id"] = id.externalID
+		profile["identity_display_name"] = id.displayName
+	}
+
+	opts := []rs.ResourceOption{
+		rs.WithAppTrait(rs.WithAppProfile(profile)),
+	}
+
+	// Bind the observation to the identity as a low-severity insight so it associates
+	// in c1's identity view. This is inventory/visibility, not a threat — hence "Low".
+	if id != nil && id.externalID != "" {
+		issueVal := fmt.Sprintf("AI coding tool '%s' (%s, %s) in use on %s by %s",
+			e.name, e.vendor, e.kind, d.Hostname, d.UserName)
+		insightOpts := []rs.SecurityInsightTraitOption{
+			rs.WithIssue(issueVal),
+			rs.WithIssueSeverity("Low"),
+			rs.WithInsightAppUserTarget(id.email, id.externalID),
+		}
+		if !d.Timestamp.IsZero() {
+			insightOpts = append(insightOpts, rs.WithInsightObservedAt(d.Timestamp))
+		}
+		insight, err := rs.NewSecurityInsightTrait(insightOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build security insight trait: %w", err)
+		}
+		opts = append(opts, rs.WithAnnotation(insight))
+	}
+
+	return rs.NewResource(displayName, resourceTypeAITool, inst.objectID(), opts...)
+}
+
+func aiToolBuilder(src *mcpSource, enabled bool) *aiToolResourceType {
+	return &aiToolResourceType{resourceType: resourceTypeAITool, src: src, enabled: enabled}
+}

--- a/pkg/connector/ai_tool_test.go
+++ b/pkg/connector/ai_tool_test.go
@@ -19,7 +19,7 @@ func TestClassifyHarness(t *testing.T) {
 		{"claude code shim", "claude-code --print hello", "Claude Code"},
 		// Claude Desktop (Electron app).
 		{"claude desktop exe", `C:\Users\a\AppData\Local\AnthropicClaude\app-0.1\Claude.exe --type=renderer`, "Claude Desktop"},
-		{"claude desktop path only", `/Applications/Claude.app/Contents/MacOS/claude.exe`, "Claude Desktop"},
+		{"claude desktop macos bundle", `/Applications/Claude.app/Contents/MacOS/Claude`, "Claude Desktop"},
 		// IDEs.
 		{"cursor exe", `C:\Users\a\AppData\Local\Programs\cursor\Cursor.exe`, "Cursor"},
 		{"cursor agent cli", "cursor-agent --resume", "Cursor"},
@@ -31,13 +31,21 @@ func TestClassifyHarness(t *testing.T) {
 		{"gemini cli scope", "npx @google/gemini-cli chat", "Gemini CLI"},
 		{"github copilot cli", "npx @github/copilot suggest", "GitHub Copilot CLI"},
 		{"opencode", "/usr/local/bin/opencode", "opencode"},
-		{"aider python", "python -m aider --model gpt-4o", "Aider"},
+		{"aider python module", "python -m aider --model gpt-4o", "Aider"},
+		// Homebrew / curl installs invoke the CLI as a bare binary (no npm scope).
+		{"codex homebrew binary", "/opt/homebrew/bin/codex --model o3", "Codex CLI"},
+		{"copilot homebrew binary", "/usr/local/bin/copilot suggest", "GitHub Copilot CLI"},
+		{"aider console script", "/usr/local/bin/aider --model gpt-4o", "Aider"},
 
 		// Negatives — guard the bare-word / broad patterns against false positives.
 		{"shadow mcp server is not a harness", "npx -y @modelcontextprotocol/server-filesystem /tmp", ""},
 		{"bare codex word does not match", "run the codex please", ""},
+		{"codex as a filename does not match", "7z x /downloads/game.CODEX.iso", ""},
 		{"bare gemini word does not match", "gemini horoscope generator", ""},
 		{"bare copilot word does not match", "microsoft copilot app", ""},
+		{"windows copilot app is not the cli", `C:\Windows\SystemApps\MicrosoftWindows.Client.Copilot\Copilot.exe`, ""},
+		{"aider unrelated wrapper script does not match", "aider.sh deploy prod", ""},
+		{"opencode as a substring does not match", "tar -xf opencode-backup.tar", ""},
 		{"plain node app", "node /srv/app/index.js", ""},
 		{"db cursor usage", "psql -c 'DECLARE cur CURSOR FOR SELECT 1'", ""},
 	}

--- a/pkg/connector/ai_tool_test.go
+++ b/pkg/connector/ai_tool_test.go
@@ -1,0 +1,134 @@
+package connector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+func TestClassifyHarness(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  string
+		wantTool string // "" means expect no match
+	}{
+		// Claude Code (must win over Claude Desktop when the package name is present).
+		{"claude code npm package", `node C:\Users\a\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\cli.js`, "Claude Code"},
+		{"claude code shim", "claude-code --print hello", "Claude Code"},
+		// Claude Desktop (Electron app).
+		{"claude desktop exe", `C:\Users\a\AppData\Local\AnthropicClaude\app-0.1\Claude.exe --type=renderer`, "Claude Desktop"},
+		{"claude desktop path only", `/Applications/Claude.app/Contents/MacOS/claude.exe`, "Claude Desktop"},
+		// IDEs.
+		{"cursor exe", `C:\Users\a\AppData\Local\Programs\cursor\Cursor.exe`, "Cursor"},
+		{"cursor agent cli", "cursor-agent --resume", "Cursor"},
+		{"windsurf exe", `C:\Program Files\Windsurf\Windsurf.exe`, "Windsurf"},
+		{"windsurf word", "/usr/local/bin/windsurf", "Windsurf"},
+		// CLI harnesses.
+		{"codex npm scope", `node /home/u/.npm/_npx/x/node_modules/@openai/codex/bin.js`, "Codex CLI"},
+		{"codex cli suffix", "openai-codex-cli run", "Codex CLI"},
+		{"gemini cli scope", "npx @google/gemini-cli chat", "Gemini CLI"},
+		{"github copilot cli", "npx @github/copilot suggest", "GitHub Copilot CLI"},
+		{"opencode", "/usr/local/bin/opencode", "opencode"},
+		{"aider python", "python -m aider --model gpt-4o", "Aider"},
+
+		// Negatives — guard the bare-word / broad patterns against false positives.
+		{"shadow mcp server is not a harness", "npx -y @modelcontextprotocol/server-filesystem /tmp", ""},
+		{"bare codex word does not match", "run the codex please", ""},
+		{"bare gemini word does not match", "gemini horoscope generator", ""},
+		{"bare copilot word does not match", "microsoft copilot app", ""},
+		{"plain node app", "node /srv/app/index.js", ""},
+		{"db cursor usage", "psql -c 'DECLARE cur CURSOR FOR SELECT 1'", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyHarness(tt.cmdline)
+			if tt.wantTool == "" {
+				if got != nil {
+					t.Fatalf("classifyHarness(%q) = %q, want no match", tt.cmdline, got.name)
+				}
+				if matchesHarness(tt.cmdline) {
+					t.Fatalf("matchesHarness(%q) = true, want false", tt.cmdline)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("classifyHarness(%q) = nil, want %q", tt.cmdline, tt.wantTool)
+			}
+			if got.name != tt.wantTool {
+				t.Fatalf("classifyHarness(%q) = %q, want %q", tt.cmdline, got.name, tt.wantTool)
+			}
+			if !matchesHarness(tt.cmdline) {
+				t.Fatalf("matchesHarness(%q) = false, want true", tt.cmdline)
+			}
+		})
+	}
+}
+
+func TestBuildAIToolInstances(t *testing.T) {
+	early := time.Date(2026, 1, 2, 8, 0, 0, 0, time.UTC)
+	late := early.Add(time.Hour)
+	dets := []mcpDetection{
+		// Two spellings of the same tool for the same (host, user) collapse to one, keep
+		// the earliest timestamp and the shortest command line.
+		{AID: "aid1", UserName: "Alice", CommandLine: "node .../@anthropic-ai/claude-code/cli.js --long-flags", Timestamp: late},
+		{AID: "aid1", UserName: "alice", CommandLine: "claude-code", Timestamp: early},
+		// Same tool, different host → distinct instance.
+		{AID: "aid2", UserName: "alice", CommandLine: "claude-code", Timestamp: late},
+		// Different tool, same host/user → distinct instance.
+		{AID: "aid1", UserName: "alice", CommandLine: `C:\cursor\Cursor.exe`, Timestamp: late},
+		// Non-harness rows are ignored.
+		{AID: "aid1", UserName: "alice", CommandLine: "npx @modelcontextprotocol/server-git", Timestamp: late},
+		// Unattributable rows are skipped.
+		{AID: "", UserName: "bob", CommandLine: "claude-code", Timestamp: late},
+	}
+	got := buildAIToolInstances(dets)
+	if len(got) != 3 {
+		t.Fatalf("got %d instances, want 3: %+v", len(got), keysOf(got))
+	}
+
+	// The aid1/alice/Claude Code instance should have collapsed both spellings.
+	var cc *aiToolInstance
+	for _, inst := range got {
+		if inst.det.AID == "aid1" && inst.entry.name == "Claude Code" {
+			cc = inst
+		}
+	}
+	if cc == nil {
+		t.Fatal("missing aid1 Claude Code instance")
+	}
+	if cc.count != 2 {
+		t.Errorf("count = %d, want 2", cc.count)
+	}
+	if !cc.det.Timestamp.Equal(early) {
+		t.Errorf("timestamp = %v, want earliest %v", cc.det.Timestamp, early)
+	}
+	if cc.bestCmdline != "claude-code" {
+		t.Errorf("bestCmdline = %q, want shortest %q", cc.bestCmdline, "claude-code")
+	}
+	if len(cc.objectID()) == 0 || cc.objectID()[:3] != "ai-" {
+		t.Errorf("objectID = %q, want ai- prefix", cc.objectID())
+	}
+}
+
+// A disabled ai_tool syncer must emit nothing and must not touch its source (so a nil
+// source is safe) — this is the opt-in, no-API-call guarantee.
+func TestAIToolDisabledEmitsNothing(t *testing.T) {
+	rt := aiToolBuilder(nil, false)
+	res, _, err := rt.List(context.Background(), nil, rs.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("disabled List returned %d resources, want 0", len(res))
+	}
+}
+
+func keysOf(m map[string]*aiToolInstance) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -23,19 +23,22 @@ type Connector struct {
 	host             string
 	ingestRiskScores bool
 	detectShadowMCP  bool
+	detectAITools    bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
-	// a single per-sync detection snapshot + identity index (consistent grants, no
-	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP)
+	// One shared EDR-detection data source feeds the mcp_server, endpoint_user, and
+	// ai_tool syncers off a single per-sync snapshot + identity index (consistent
+	// grants, no redundant Alerts / Identity-Protection calls). The source scans when
+	// either detection capability is on; each syncer decides what it emits.
+	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP || o.detectAITools)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
 		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores),
-		mcpServerBuilder(o.client, mcpSrc),
-		endpointUserBuilder(mcpSrc),
+		mcpServerBuilder(o.client, mcpSrc, o.detectShadowMCP),
+		endpointUserBuilder(mcpSrc, o.detectShadowMCP),
+		aiToolBuilder(mcpSrc, o.detectAITools),
 	}
 }
 
@@ -176,5 +179,6 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		host:             host,
 		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
 		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,
+		detectAITools:    cc.CrowdstrikeDetectAiTools,
 	}, nil, nil
 }

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -44,6 +44,10 @@ type mcpServerResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	src          *mcpSource
+	// enabled gates shadow-MCP detection specifically. The shared source may still run
+	// its scan for a sibling capability (AI-tool inventory), so this flag — not the
+	// source's — decides whether shadow-MCP resources are emitted.
+	enabled bool
 }
 
 func (m *mcpServerResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -87,6 +91,9 @@ type resolvedIdentity struct {
 // List scans recent EDR detections for shadow-MCP activity, correlates each to an
 // identity, and returns one mcp_server resource per unique server instance.
 func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !m.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
 	dets, err := m.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
@@ -271,6 +278,9 @@ func (inst *mcpServerInstance) accountID() string {
 type endpointUserResourceType struct {
 	resourceType *v2.ResourceType
 	src          *mcpSource
+	// enabled gates the endpoint-user accounts that back shadow-MCP resources; tied to
+	// the shadow-MCP capability, not the shared source (see mcpServerResourceType).
+	enabled bool
 }
 
 func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -278,6 +288,9 @@ func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceT
 }
 
 func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !e.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
 	dets, err := e.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
@@ -583,7 +596,11 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			return nil, err
 		}
 		for _, a := range e.Resources {
-			if a.Product != "epp" || !mcpSignature.MatchString(a.Cmdline) {
+			// Keep an alert if its command line looks like a shadow MCP server OR a
+			// known AI coding tool/harness — both capabilities read this one shared
+			// scan and each re-classifies the snapshot downstream.
+			aiRelated := mcpSignature.MatchString(a.Cmdline) || matchesHarness(a.Cmdline)
+			if a.Product != "epp" || !aiRelated {
 				continue
 			}
 			if a.Device.DeviceID == "" || a.UserName == "" {
@@ -600,15 +617,17 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 	return out, nil
 }
 
-// mcpSource is a per-connector data source shared by the mcp_server and endpoint_user
-// syncers. It memoizes the detection snapshot and identity index per sync (keyed by
-// SyncID) so every List/Grants call across both resource types sees one consistent
+// mcpSource is a per-connector data source shared by the mcp_server, endpoint_user, and
+// ai_tool syncers. It memoizes the detection snapshot and identity index per sync (keyed
+// by SyncID) so every List/Grants call across those resource types sees one consistent
 // snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
 // that independent re-fetches would cause. Only the current sync's data is retained.
 type mcpSource struct {
-	// enabled gates shadow-MCP detection. When false (the default), detections and
-	// the identity index are no-ops that make no CrowdStrike API calls, so the
-	// mcp_server / endpoint_user syncers produce nothing — the capability is opt-in.
+	// enabled gates the shared scan. It is the OR of the shadow-MCP and AI-tool
+	// capabilities: when both are off (the default) detections and the identity index
+	// are no-ops that make no CrowdStrike API calls. Which resources actually get
+	// emitted is decided per-syncer (see the enabled flag on each resource type), since
+	// one capability can be on while the other is off.
 	enabled bool
 
 	detClient *mcpDetectionsClient
@@ -675,10 +694,10 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	return idx, nil
 }
 
-func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {
-	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src}
+func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource, enabled bool) *mcpServerResourceType {
+	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src, enabled: enabled}
 }
 
-func endpointUserBuilder(src *mcpSource) *endpointUserResourceType {
-	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src}
+func endpointUserBuilder(src *mcpSource, enabled bool) *endpointUserResourceType {
+	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src, enabled: enabled}
 }

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -93,4 +93,24 @@ var (
 			),
 		),
 	}
+	// resourceTypeAITool models an AI coding tool ("harness" — Claude Code, Cursor,
+	// codex, etc.) observed running on an endpoint via CrowdStrike EDR detections. It
+	// carries an App-trait inventory profile (tool, endpoint, and resolved-identity
+	// metadata) and a low-severity security-insight annotation associating the tool with
+	// the identity that ran it. This is governance visibility, not a threat finding.
+	resourceTypeAITool = &v2.ResourceType{
+		Id:          "ai_tool",
+		DisplayName: "AI Coding Tool",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_APP,
+			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+				"Identity Protection GraphQL: Write",
+			),
+		),
+	}
 )

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -106,6 +106,7 @@ var (
 			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
 		},
 		Annotations: annotations.New(
+			&v2.SkipEntitlementsAndGrants{},
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",


### PR DESCRIPTION
Adds an `ai_tool` resource type that inventories AI coding tools ("harnesses" — Claude Code, Claude Desktop, Cursor, Windsurf, OpenAI Codex, Gemini CLI, GitHub Copilot CLI, opencode, Aider) observed running on endpoints via CrowdStrike EDR detections, correlated to the identity that ran each, as a low-severity governance insight.

## What it does
- New `ai_tool` resource type: an App-trait inventory profile (tool, vendor, category, host, sample command line, resolved identity) plus a low-severity security insight binding the observation to the identity that ran it.
- Reuses the shadow-MCP detection pipeline: one shared Alerts scan + identity index now feeds `mcp_server`, `endpoint_user`, and `ai_tool`. The shared scan runs when either capability is enabled; each syncer re-classifies the snapshot and is gated independently.

## Opt-in
- New `crowdstrike-detect-ai-tools` config flag, **off by default**. When off, the syncer emits nothing and makes no additional API calls.
- Requires `Alerts: Read` plus the Identity Protection scopes (same as shadow-MCP detection).

## How detection works
CrowdStrike doesn't flag AI coding tools by default, so an operator authors a Custom IOA (Process Creation, Detect disposition) matching common harness command lines. The connector reads the resulting endpoint detections via the Alerts API and classifies each to a known tool. Because these are ordinary developer tools, a detection is raised each time one launches. Docs updated with the rule and setup.

## Testing
- Unit tests for classification (including false-positive guards for bare tool names) and opt-in gating.
- Verified end-to-end against a live tenant: real harness launches produced EDR detections that synced into correctly-classified, deduplicated `ai_tool` resources.

Stacked on #64 (base branch `leet/shadow-mcp-detection`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
