### PR TITLE
feat: shadow MCP, AI tools, password risk (combined stack + OptIn fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,19 @@ baton resources
 
 - **Users** (`user`) — Falcon console users; `uuid` is the stable resource ID and `uid` is the login/email
 - **Roles** (`role`) — Falcon roles (e.g. `falcon_administrator`, `falcon_analyst`, `falcon_read_only`) with a `member` assignment entitlement
-- **Identity Risk Scores** (`security_insight`) — Falcon Identity Protection risk scores (opt-in, disabled by default)
-- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (see below)
-- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually)
+- **Identity Risk Scores** (`security_insight`) — Falcon Identity Protection risk scores (C1 opt-in capability)
+- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (C1 opt-in capability)
+- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually) (C1 opt-in capability)
+- **AI Coding Tools** (`ai_tool`) — AI harness inventory from EDR detections, correlated to identities (C1 opt-in capability)
 
 | Resource             | Sync | Provision                                          |
 | -------------------- | ---- | -------------------------------------------------- |
 | Users                | Yes  | Yes (create / delete, and update first/last name)  |
 | Roles                | Yes  | Yes (Grant / Revoke role membership)               |
-| Shadow MCP Servers   | Yes  | No                                                 |
-| Endpoint Users       | Yes  | No                                                 |
-| Identity Risk Scores | Yes  | No (synced read-only, opt-in)                      |
+| Shadow MCP Servers   | Yes (opt-in) | No                                                 |
+| Endpoint Users       | Yes (opt-in) | No                                                 |
+| AI Coding Tools      | Yes (opt-in) | No                                                 |
+| Identity Risk Scores | Yes (opt-in) | No (synced read-only)                              |
 
 # Provisioning
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # `baton-crowdstrike` [![Go Reference](https://pkg.go.dev/badge/github.com/conductorone/baton-crowdstrike.svg)](https://pkg.go.dev/github.com/conductorone/baton-crowdstrike) ![verify](https://github.com/conductorone/baton-crowdstrike/actions/workflows/verify.yaml/badge.svg)
 
-`baton-crowdstrike` is a connector for CrowdStrike built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It works with the CrowdStrike Falcon API to sync users, roles, and identity risk scores, with provisioning support for account creation/deletion, role membership, and user profile updates.
+`baton-crowdstrike` is a connector for CrowdStrike built using the [Baton SDK](https://github.com/conductorone/baton-sdk). It works with the CrowdStrike Falcon API to sync users, roles, identity risk scores, and shadow MCP servers, with provisioning support for account creation/deletion, role membership, and user profile updates.
 
 Check out [Baton](https://github.com/conductorone/baton) to learn more about the project in general.
 
@@ -18,6 +18,7 @@ The connector requires a **client ID and secret** to exchange for an access toke
 | **User Management: Write**             | For provisioning  | Create/delete users, grant/revoke roles, update name |
 | **Identity Protection Entities: Read** | For risk scores   | Sync identity risk scores (opt-in `security_insight`)|
 | **Identity Protection GraphQL: Write** | For risk scores   | Required by CrowdStrike to fetch risk score data     |
+| **Alerts: Read**                       | For shadow MCP    | Read EDR detections to discover shadow MCP servers and their endpoint users (`mcp_server`, `endpoint_user`) |
 
 # Getting Started
 
@@ -67,11 +68,15 @@ baton resources
 - **Users** (`user`) — Falcon console users; `uuid` is the stable resource ID and `uid` is the login/email
 - **Roles** (`role`) — Falcon roles (e.g. `falcon_administrator`, `falcon_analyst`, `falcon_read_only`) with a `member` assignment entitlement
 - **Identity Risk Scores** (`security_insight`) — Falcon Identity Protection risk scores (opt-in, disabled by default)
+- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (see below)
+- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually)
 
 | Resource             | Sync | Provision                                          |
 | -------------------- | ---- | -------------------------------------------------- |
 | Users                | Yes  | Yes (create / delete, and update first/last name)  |
 | Roles                | Yes  | Yes (Grant / Revoke role membership)               |
+| Shadow MCP Servers   | Yes  | No                                                 |
+| Endpoint Users       | Yes  | No                                                 |
 | Identity Risk Scores | Yes  | No (synced read-only, opt-in)                      |
 
 # Provisioning
@@ -151,6 +156,26 @@ The connector can sync identity risk scores from CrowdStrike Identity Protection
 - **Risk Factors**: The factors contributing to the risk score (e.g. "WEAK_PASSWORD (HIGH)", "MFA_NOT_ENABLED (MEDIUM)")
 
 To sync security insights, your CrowdStrike API client must have the **Identity Protection Entities: Read** and **Identity Protection GraphQL: Write** scopes enabled. The `security_insight` resource type is disabled by default and can be enabled through ConductorOne.
+
+# Shadow MCP Servers
+
+The connector discovers unsanctioned ("shadow") [Model Context Protocol](https://modelcontextprotocol.io) servers running on managed endpoints and correlates each to the identity that ran it — surfacing ungoverned AI-agent tooling that never passed through a sanctioned gateway.
+
+An MCP server is an ordinary `npx` / `uvx` / `node` / `python` process whose command line carries a recognizable package (`@modelcontextprotocol/server-*`, `mcp-server-*`, `mcp_server_*`) — the **MCP signature**. The connector reads CrowdStrike EDR detections (via the Alerts API), matches that signature, deduplicates by (host, endpoint user, server), and emits one `mcp_server` resource per instance with:
+
+- an **App-trait profile**: `server_name`, `package`, `launcher`, `transport`, `host`, `aid`, `local_ip`, `endpoint_user`, `sample_command_line`, `detection_count`, `ioa_rule`, `falcon_link`, `sanctioned` (always `false`), plus `first_seen` when a detection timestamp is available and `identity_email` / `identity_external_id` / `identity_display_name` when the endpoint user resolves to an Identity Protection entity;
+- a **security-insight** issue (always `High`) bound to that identity (`AppUser` target), so the finding flows into the identity's risk in ConductorOne.
+
+### Account & grant chain
+
+Correlation is also modeled as a normal account/entitlement/grant chain, so a shadow MCP shows up against a real person in access reviews — not just as profile metadata:
+
+- each shadow-MCP instance produces an **`endpoint_user`** account resource (the OS user that ran it), matched to a ConductorOne identity by email when the endpoint user resolves to an Identity Protection entity, or **assignable manually** otherwise;
+- each `mcp_server` resource exposes a **`runner`** assignment entitlement, granted to the `endpoint_user` account that ran it.
+
+The result is a **c1 identity → `endpoint_user` account → `runner` grant → `mcp_server`** chain, alongside the identity-risk security insight above.
+
+To detect the servers natively, author a **Custom IOA** rule (Process Creation, Detect disposition) matching the command-line signature `(@modelcontextprotocol/server-|mcp-server-|mcp_server_)` so CrowdStrike raises a detection the connector can read. Endpoint users are resolved to identities via Identity Protection `samAccountName` (or email local-part). The `mcp_server` and `endpoint_user` resource types both require the **Alerts: Read** scope (plus the Identity Protection scopes above for correlation).
 
 # Contributing, Support and Issues
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ baton resources
 - **Users** (`user`) — Falcon console users; `uuid` is the stable resource ID and `uid` is the login/email
 - **Roles** (`role`) — Falcon roles (e.g. `falcon_administrator`, `falcon_analyst`, `falcon_read_only`) with a `member` assignment entitlement
 - **Identity Risk Scores** (`security_insight`) — Falcon Identity Protection risk scores (C1 opt-in capability)
-- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (C1 opt-in capability)
-- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually) (C1 opt-in capability)
+- **Shadow MCP Servers** (`mcp_server`) — unsanctioned [Model Context Protocol](https://modelcontextprotocol.io) servers observed running on endpoints via EDR detections, correlated to the identity that ran them (C1 opt-in capability; enable together with `endpoint_user` so runner grants resolve)
+- **Endpoint Users** (`endpoint_user`) — the endpoint OS users that ran a shadow MCP server, modeled as app accounts; each holds the `runner` grant on the servers it ran and is matched to a ConductorOne identity by email (or assigned manually) (C1 opt-in capability; enable together with `mcp_server`)
 - **AI Coding Tools** (`ai_tool`) — AI harness inventory from EDR detections, correlated to identities (C1 opt-in capability)
 
 | Resource             | Sync | Provision                                          |
@@ -177,7 +177,9 @@ Correlation is also modeled as a normal account/entitlement/grant chain, so a sh
 
 The result is a **c1 identity → `endpoint_user` account → `runner` grant → `mcp_server`** chain, alongside the identity-risk security insight above.
 
-To detect the servers natively, author a **Custom IOA** rule (Process Creation, Detect disposition) matching the command-line signature `(@modelcontextprotocol/server-|mcp-server-|mcp_server_)` so CrowdStrike raises a detection the connector can read. Endpoint users are resolved to identities via Identity Protection `samAccountName` (or email local-part). The `mcp_server` and `endpoint_user` resource types both require the **Alerts: Read** scope (plus the Identity Protection scopes above for correlation).
+To detect the servers natively, author a **Custom IOA** rule (Process Creation, Detect disposition) matching the command-line signature `(@modelcontextprotocol/server-|mcp-server-|mcp_server_)` so CrowdStrike raises a detection the connector can read. Endpoint users are resolved to identities via Identity Protection `samAccountName` (or email local-part). The `mcp_server` and `endpoint_user` resource types both require the **Alerts: Read** scope (plus the Identity Protection scopes above for correlation). Enable **both** capabilities in C1 so the runner grant graph resolves.
+
+Inventory is a recent epp Alerts scan window (capped by page limits), not full historical state — high alert volume can shorten lookback and drop older detections from a later sync without a hard failure.
 
 # Contributing, Support and Issues
 

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -72,6 +72,9 @@
               },
               {
                 "permission": "Identity Protection Entities: Read"
+              },
+              {
+                "permission": "Identity Protection GraphQL: Write"
               }
             ]
           }
@@ -87,6 +90,9 @@
           },
           {
             "permission": "Identity Protection Entities: Read"
+          },
+          {
+            "permission": "Identity Protection GraphQL: Write"
           }
         ]
       },

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -3,6 +3,48 @@
   "resourceTypeCapabilities": [
     {
       "resourceType": {
+        "id": "ai_tool",
+        "displayName": "AI Coding Tool",
+        "traits": [
+          "TRAIT_APP",
+          "TRAIT_SECURITY_INSIGHT"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              },
+              {
+                "permission": "Identity Protection GraphQL: Write"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          },
+          {
+            "permission": "Identity Protection GraphQL: Write"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
         "id": "endpoint_user",
         "displayName": "Endpoint User",
         "traits": [

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -3,6 +3,86 @@
   "resourceTypeCapabilities": [
     {
       "resourceType": {
+        "id": "endpoint_user",
+        "displayName": "Endpoint User",
+        "traits": [
+          "TRAIT_USER"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
+        "id": "mcp_server",
+        "displayName": "Shadow MCP Server",
+        "traits": [
+          "TRAIT_APP",
+          "TRAIT_SECURITY_INSIGHT"
+        ],
+        "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
+            "permissions": [
+              {
+                "permission": "Alerts: Read"
+              },
+              {
+                "permission": "Identity Protection Entities: Read"
+              },
+              {
+                "permission": "Identity Protection GraphQL: Write"
+              }
+            ]
+          }
+        ]
+      },
+      "capabilities": [
+        "CAPABILITY_SYNC"
+      ],
+      "permissions": {
+        "permissions": [
+          {
+            "permission": "Alerts: Read"
+          },
+          {
+            "permission": "Identity Protection Entities: Read"
+          },
+          {
+            "permission": "Identity Protection GraphQL: Write"
+          }
+        ]
+      }
+    },
+    {
+      "resourceType": {
         "id": "role",
         "displayName": "Role",
         "traits": [

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -11,6 +11,9 @@
         ],
         "annotations": [
           {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -14,6 +14,9 @@
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           },
           {
+            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {
@@ -44,7 +47,8 @@
             "permission": "Identity Protection GraphQL: Write"
           }
         ]
-      }
+      },
+      "optInRequired": true
     },
     {
       "resourceType": {
@@ -58,6 +62,9 @@
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
           },
           {
+            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
+          },
+          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {
@@ -82,7 +89,8 @@
             "permission": "Identity Protection Entities: Read"
           }
         ]
-      }
+      },
+      "optInRequired": true
     },
     {
       "resourceType": {
@@ -93,6 +101,9 @@
           "TRAIT_SECURITY_INSIGHT"
         ],
         "annotations": [
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.OptInRequired"
+          },
           {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
@@ -124,7 +135,8 @@
             "permission": "Identity Protection GraphQL: Write"
           }
         ]
-      }
+      },
+      "optInRequired": true
     },
     {
       "resourceType": {

--- a/config_schema.json
+++ b/config_schema.json
@@ -132,29 +132,9 @@
       }
     },
     {
-      "name": "crowdstrike-ingest-risk-scores",
-      "displayName": "Ingest identity risk scores",
-      "description": "On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as security insights on identities; requires the Identity Protection scopes. Turn off to disable.",
-      "boolField": {
-        "defaultValue": true
-      }
-    },
-    {
-      "name": "crowdstrike-detect-shadow-mcp",
-      "displayName": "Detect shadow MCP servers",
-      "description": "Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint users that ran them, correlated to identities. Off by default; requires the Alerts read scope.",
-      "boolField": {}
-    },
-    {
       "name": "crowdstrike-ingest-password-risk",
       "displayName": "Ingest identity password risk",
       "description": "Opt-in. When enabled, surface Identity Protection password risk on identity insights — a compromised (exposed) password as an EXPOSED_PASSWORD risk factor and a weak password as a WEAK_PASSWORD risk factor. Off by default; uses the same Identity Protection scopes as risk score ingestion.",
-      "boolField": {}
-    },
-    {
-      "name": "crowdstrike-detect-ai-tools",
-      "displayName": "Detect AI coding tools",
-      "description": "Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the Alerts read scope.",
       "boolField": {}
     }
   ],

--- a/config_schema.json
+++ b/config_schema.json
@@ -130,6 +130,18 @@
           ]
         }
       }
+    },
+    {
+      "name": "crowdstrike-ingest-risk-scores",
+      "displayName": "Ingest identity risk scores",
+      "description": "Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors as security insights on identities. Off by default; requires the Identity Protection scopes.",
+      "boolField": {}
+    },
+    {
+      "name": "crowdstrike-detect-shadow-mcp",
+      "displayName": "Detect shadow MCP servers",
+      "description": "Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint users that ran them, correlated to identities. Off by default; requires the Alerts read scope.",
+      "boolField": {}
     }
   ],
   "displayName": "CrowdStrike",

--- a/config_schema.json
+++ b/config_schema.json
@@ -150,6 +150,12 @@
       "displayName": "Ingest identity password risk",
       "description": "Opt-in. When enabled, surface Identity Protection password risk on identity insights — a compromised (exposed) password as an EXPOSED_PASSWORD risk factor and a weak password as a WEAK_PASSWORD risk factor. Off by default; uses the same Identity Protection scopes as risk score ingestion.",
       "boolField": {}
+    },
+    {
+      "name": "crowdstrike-detect-ai-tools",
+      "displayName": "Detect AI coding tools",
+      "description": "Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the Alerts read scope.",
+      "boolField": {}
     }
   ],
   "displayName": "CrowdStrike",

--- a/config_schema.json
+++ b/config_schema.json
@@ -134,8 +134,10 @@
     {
       "name": "crowdstrike-ingest-risk-scores",
       "displayName": "Ingest identity risk scores",
-      "description": "Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors as security insights on identities. Off by default; requires the Identity Protection scopes.",
-      "boolField": {}
+      "description": "On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as security insights on identities; requires the Identity Protection scopes. Turn off to disable.",
+      "boolField": {
+        "defaultValue": true
+      }
     },
     {
       "name": "crowdstrike-detect-shadow-mcp",

--- a/config_schema.json
+++ b/config_schema.json
@@ -144,6 +144,12 @@
       "displayName": "Detect shadow MCP servers",
       "description": "Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint users that ran them, correlated to identities. Off by default; requires the Alerts read scope.",
       "boolField": {}
+    },
+    {
+      "name": "crowdstrike-ingest-password-risk",
+      "displayName": "Ingest identity password risk",
+      "description": "Opt-in. When enabled, surface Identity Protection password risk on identity insights — a compromised (exposed) password as an EXPOSED_PASSWORD risk factor and a weak password as a WEAK_PASSWORD risk factor. Off by default; uses the same Identity Protection scopes as risk score ingestion.",
+      "boolField": {}
     }
   ],
   "displayName": "CrowdStrike",

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -247,6 +247,8 @@ spec:
 
 The CrowdStrike connector can ingest Falcon identity risk scores and surface them in C1 during access reviews and access request approvals. See [External insights](/product/admin/external-insights) for an overview of where risk data appears.
 
+Alongside the overall risk score and Identity Protection risk factors, the connector also surfaces per-account **password risk** as risk factors on the insight: a compromised (exposed) password appears as a high-severity `EXPOSED_PASSWORD` factor, and a weak password as a medium-severity `WEAK_PASSWORD` factor. No additional scopes are required — this data comes through the same Identity Protection query.
+
 ### Before you begin
 
 Confirm that:

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -12,7 +12,7 @@ sidebarTitle: "CrowdStrike"
 | :--- | :--- | :--- |
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
-| Insights (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Insights | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
@@ -278,9 +278,9 @@ The CrowdStrike API client you created during connector setup needs additional s
   </Step>
 </Steps>
 
-### Turn on risk score ingestion
+### Risk score ingestion setting
 
-In C1, open the connector's **Settings** and enable **Ingest identity risk scores** (off by default), then save.
+Risk score ingestion is **on by default**. Once the scopes above are in place, the connector syncs it automatically — no further action needed. To disable it, open the connector's **Settings** in C1, turn off **Ingest identity risk scores**, and save.
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
 

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -15,6 +15,7 @@ sidebarTitle: "CrowdStrike"
 | Insights | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| AI coding tools (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
 ### Connector actions
 
@@ -354,3 +355,56 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
 In C1, open the connector's **Settings** and enable **Detect shadow MCP servers** (off by default), then save.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.
+
+## Detect AI coding tools
+
+<Warning>
+**Early access.** This feature is in early access, which means it's undergoing ongoing testing and development while we gather feedback, validate functionality, and improve outputs. Contact the C1 Support team if you'd like to try it out or share feedback.
+</Warning>
+
+The CrowdStrike connector can inventory **AI coding tools** ("harnesses" — Claude Code, Claude Desktop, Cursor, Windsurf, OpenAI Codex, Gemini CLI, GitHub Copilot CLI, opencode, Aider, and similar) observed running on your endpoints, and correlate each to the identity that ran it. This gives you governance visibility into which people are using which AI tools on which hosts. It reads CrowdStrike endpoint detections and models each tool as an **`ai_tool`** resource describing the tool (name, vendor, category, host, sample command line, and the identity it resolved to), with a low-severity insight linking it to that identity.
+
+This shares the same detection pipeline as shadow MCP detection — it reads the Alerts API and resolves endpoint users to identities the same way — but is turned on and off independently.
+
+### Before you begin
+
+Confirm that:
+
+- Your CrowdStrike environment generates endpoint detections (the connector reads them via the Alerts API)
+- You have the **Falcon Administrator** role in CrowdStrike
+- Your CrowdStrike connector is already set up and syncing in C1
+
+### Add the required API scope
+
+The **Alerts: Read** scope is required (the same scope shadow MCP detection uses). Keep **Identity Protection Entities: Read** enabled so AI-tool usage can be matched to identities. If you already enabled these for shadow MCP detection, no change is needed.
+
+### Create a detection rule for AI coding tools
+
+CrowdStrike doesn't flag AI coding tools by default, so you author a Custom IOA rule that raises a detection the connector can read.
+
+<Steps>
+  <Step>
+  In the Falcon console, create or open a **Custom IOA rule group** for each platform you want to cover (Windows, macOS, Linux).
+  </Step>
+  <Step>
+  Add a **Process Creation** rule with the **Detect** disposition.
+  </Step>
+  <Step>
+  Set the rule's **Command Line** field to match common AI coding tools:
+
+  ```
+  (?i).*(claude-code|[\\/]claude\.(exe|app)|[\\/]cursor\.(exe|app)|cursor-agent|[\\/]windsurf|@openai[\\/]codex|codex-cli|@github[\\/]copilot|copilot-cli|gemini-cli|[\\/]opencode|[\\/]aider).*
+  ```
+
+  Adjust the list to the tools you want to track. The pattern anchors tool names to executables and package paths (rather than matching the bare words "codex" or "copilot" anywhere) to avoid raising detections on unrelated software. Because AI coding tools are ordinary developer software rather than threats, expect a detection each time one launches.
+  </Step>
+  <Step>
+  Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
+  </Step>
+</Steps>
+
+### Turn on AI coding tool detection
+
+In C1, open the connector's **Settings** and enable **Detect AI coding tools** (off by default), then save.
+
+**Done.** As endpoints run AI coding tools, CrowdStrike raises detections and the connector syncs them into C1 as `ai_tool` resources correlated to the identities that ran them.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -352,7 +352,18 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
 
 ### Turn on shadow MCP detection
 
-In C1, enable the **Shadow MCP Server** and **Endpoint User** capabilities on the connector (these resource types are opt-in via C1 capability mediation, not a connector config flag), then save and re-sync.
+In C1, enable **both** the **Shadow MCP Server** and **Endpoint User** capabilities on the connector (these resource types are opt-in via C1 capability mediation, not a connector config flag), then save and re-sync.
+
+**Enable them together.** Shadow MCP `runner` grants use `endpoint_user` principals. If only Shadow MCP Server is enabled and Endpoint User is off, C1 will not list those principals and the runner grant graph will not fully resolve.
+
+### Detection inventory window (page caps)
+
+Shadow MCP inventory is a **recent endpoint-protection (epp) alert scan window**, not full historical state:
+
+- Alerts are scanned newest-first, bounded by `mcpAlertMaxPages` (10 pages × 1000 alerts per page).
+- Identity correlation indexes Identity Protection entities up to `mcpIdentityIndexMaxPages` pages.
+
+If epp volume is high, the effective lookback shortens. Detections (and thus `mcp_server` / `endpoint_user` resources) that fall outside the scanned window can drop from a later sync **without a hard sync failure** — the connector logs a warning when a page cap is hit and continues with partial results. Re-enablement or lower epp noise restores visibility when those detections reappear in the window.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.
 
@@ -406,5 +417,9 @@ CrowdStrike doesn't flag AI coding tools by default, so you author a Custom IOA 
 ### Turn on AI coding tool detection
 
 In C1, enable the **AI Coding Tool** capability on the connector (opt-in via C1 capability mediation, not a connector config flag), then save and re-sync.
+
+### Detection inventory window (page caps)
+
+AI coding tool inventory shares the same Alerts scan as shadow MCP detection. Inventory is a **recent epp alert scan window** bounded by `mcpAlertMaxPages` (and identity correlation by `mcpIdentityIndexMaxPages`), not full historical state. High epp volume shortens effective lookback; tools that fall outside the window can disappear from a later sync without a hard failure (a warning is logged when the page cap is hit). See [Detect shadow MCP servers](#detect-shadow-mcp-servers) for the same semantics.
 
 **Done.** As endpoints run AI coding tools, CrowdStrike raises detections and the connector syncs them into C1 as `ai_tool` resources correlated to the identities that ran them.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -278,6 +278,10 @@ The CrowdStrike API client you created during connector setup needs additional s
   </Step>
 </Steps>
 
+### Turn on risk score ingestion
+
+In C1, open the connector's **Settings** and enable **Ingest identity risk scores** (off by default), then save.
+
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
 
 ## Detect shadow MCP servers
@@ -340,5 +344,9 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
   Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
   </Step>
 </Steps>
+
+### Turn on shadow MCP detection
+
+In C1, open the connector's **Settings** and enable **Detect shadow MCP servers** (off by default), then save.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -13,6 +13,8 @@ sidebarTitle: "CrowdStrike"
 | Accounts | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Roles | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Insights (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Shadow MCP servers (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
+| Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
 ### Connector actions
 
@@ -277,3 +279,66 @@ The CrowdStrike API client you created during connector setup needs additional s
 </Steps>
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
+
+## Detect shadow MCP servers
+
+<Warning>
+**Early access.** This feature is in early access, which means it's undergoing ongoing testing and development while we gather feedback, validate functionality, and improve outputs. Contact the C1 Support team if you'd like to try it out or share feedback.
+</Warning>
+
+The CrowdStrike connector can surface unsanctioned ("shadow") [Model Context Protocol](https://modelcontextprotocol.io) servers running on your endpoints — ungoverned AI-agent tooling that never passed through a sanctioned gateway — and correlate each to the identity that ran it. It reads CrowdStrike endpoint detections and models each shadow server as:
+
+- an **`mcp_server`** resource describing the server (package, launcher, transport, host, sample command line, and the identity it resolved to), and
+- an **`endpoint_user`** account for the OS user that ran it, holding a **runner** grant on that server.
+
+Assign the endpoint-user account to a C1 identity (or it auto-matches by email when the endpoint user resolves in Identity Protection) so the shadow MCP shows up against a real person in access reviews.
+
+### Before you begin
+
+Confirm that:
+
+- Your CrowdStrike environment generates endpoint detections (the connector reads them via the Alerts API)
+- You have the **Falcon Administrator** role in CrowdStrike
+- Your CrowdStrike connector is already set up and syncing in C1
+
+### Add the required API scope
+
+<Steps>
+  <Step>
+  Sign into the Falcon console and navigate to **Support** > **API Clients and Keys**.
+  </Step>
+  <Step>
+  Find the API client you created for the C1 integration and click to edit it.
+  </Step>
+  <Step>
+  In the **API SCOPES** section, enable **Alerts: Read**. Keep the **Identity Protection Entities: Read** scope enabled (from risk score ingestion) so endpoint users can be matched to identities.
+  </Step>
+  <Step>
+  Click **Save**.
+  </Step>
+</Steps>
+
+### Create a detection rule for MCP servers
+
+CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule that raises a detection the connector can read. An MCP server is an ordinary `npx`, `uvx`, `node`, or `python` process whose command line contains a recognizable package name (`@modelcontextprotocol/server-*`, `mcp-server-*`, or `mcp_server_*`).
+
+<Steps>
+  <Step>
+  In the Falcon console, create or open a **Custom IOA rule group** for each platform you want to cover (Windows, macOS, Linux).
+  </Step>
+  <Step>
+  Add a **Process Creation** rule with the **Detect** disposition.
+  </Step>
+  <Step>
+  Set the rule's **Command Line** field to match the MCP signature:
+
+  ```
+  (?i).*(@modelcontextprotocol/server-|mcp-server-|mcp_server_).*
+  ```
+  </Step>
+  <Step>
+  Enable the rule and the rule group, then assign the group to the prevention policy that applies to those hosts.
+  </Step>
+</Steps>
+
+**Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -285,7 +285,7 @@ The CrowdStrike API client you created during connector setup needs additional s
 
 ### Risk score ingestion setting
 
-Risk score ingestion is **on by default**. Once the scopes above are in place, the connector syncs it automatically — no further action needed. To disable it, open the connector's **Settings** in C1, turn off **Ingest identity risk scores**, and save.
+Identity risk scores use the **Identity Risk Score** (`security_insight`) capability, which is opt-in in C1. Once the scopes above are in place and the capability is enabled, the connector syncs risk scores automatically. There is no connector config flag that empties this resource type.
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
 
@@ -352,7 +352,7 @@ CrowdStrike doesn't flag MCP servers by default, so you author a Custom IOA rule
 
 ### Turn on shadow MCP detection
 
-In C1, open the connector's **Settings** and enable **Detect shadow MCP servers** (off by default), then save.
+In C1, enable the **Shadow MCP Server** and **Endpoint User** capabilities on the connector (these resource types are opt-in via C1 capability mediation, not a connector config flag), then save and re-sync.
 
 **Done.** As endpoints run MCP servers, CrowdStrike raises detections and the connector syncs them into C1 as `mcp_server` resources and `endpoint_user` accounts. Assign each endpoint-user account to a C1 identity to attribute the finding.
 
@@ -364,7 +364,7 @@ In C1, open the connector's **Settings** and enable **Detect shadow MCP servers*
 
 The CrowdStrike connector can inventory **AI coding tools** ("harnesses" — Claude Code, Claude Desktop, Cursor, Windsurf, OpenAI Codex, Gemini CLI, GitHub Copilot CLI, opencode, Aider, and similar) observed running on your endpoints, and correlate each to the identity that ran it. This gives you governance visibility into which people are using which AI tools on which hosts. It reads CrowdStrike endpoint detections and models each tool as an **`ai_tool`** resource describing the tool (name, vendor, category, host, sample command line, and the identity it resolved to), with a low-severity insight linking it to that identity.
 
-This shares the same detection pipeline as shadow MCP detection — it reads the Alerts API and resolves endpoint users to identities the same way — but is turned on and off independently.
+This shares the same detection pipeline as shadow MCP detection — it reads the Alerts API and resolves endpoint users to identities the same way — but is enabled independently via the **AI Coding Tool** C1 capability.
 
 ### Before you begin
 
@@ -405,6 +405,6 @@ CrowdStrike doesn't flag AI coding tools by default, so you author a Custom IOA 
 
 ### Turn on AI coding tool detection
 
-In C1, open the connector's **Settings** and enable **Detect AI coding tools** (off by default), then save.
+In C1, enable the **AI Coding Tool** capability on the connector (opt-in via C1 capability mediation, not a connector config flag), then save and re-sync.
 
 **Done.** As endpoints run AI coding tools, CrowdStrike raises detections and the connector syncs them into C1 as `ai_tool` resources correlated to the identities that ran them.

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -247,7 +247,9 @@ spec:
 
 The CrowdStrike connector can ingest Falcon identity risk scores and surface them in C1 during access reviews and access request approvals. See [External insights](/product/admin/external-insights) for an overview of where risk data appears.
 
-Alongside the overall risk score and Identity Protection risk factors, the connector also surfaces per-account **password risk** as risk factors on the insight: a compromised (exposed) password appears as a high-severity `EXPOSED_PASSWORD` factor, and a weak password as a medium-severity `WEAK_PASSWORD` factor. No additional scopes are required — this data comes through the same Identity Protection query.
+<Note>
+**Optional: password risk.** The connector can additionally surface per-account **password risk** as risk factors on the insight — a compromised (exposed) password as a high-severity `EXPOSED_PASSWORD` factor, and a weak password as a medium-severity `WEAK_PASSWORD` factor. This is **opt-in and off by default**: enable the **Ingest identity password risk** setting on the connector to turn it on. No additional scopes are required — it uses the same Identity Protection query.
+</Note>
 
 ### Before you begin
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/quasilyte/go-ruleguard/dsl v0.3.23
 	go.uber.org/zap v1.28.0
-	golang.org/x/oauth2 v0.36.0
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -148,6 +147,7 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -10,6 +10,7 @@ type Crowdstrike struct {
 	BaseUrl string `mapstructure:"base-url"`
 	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
 	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
+	CrowdstrikeIngestPasswordRisk bool `mapstructure:"crowdstrike-ingest-password-risk"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,8 @@ type Crowdstrike struct {
 	CrowdstrikeClientSecret string `mapstructure:"crowdstrike-client-secret"`
 	Region string `mapstructure:"region"`
 	BaseUrl string `mapstructure:"base-url"`
+	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
+	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -11,6 +11,7 @@ type Crowdstrike struct {
 	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
 	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
 	CrowdstrikeIngestPasswordRisk bool `mapstructure:"crowdstrike-ingest-password-risk"`
+	CrowdstrikeDetectAiTools bool `mapstructure:"crowdstrike-detect-ai-tools"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,10 +8,7 @@ type Crowdstrike struct {
 	CrowdstrikeClientSecret string `mapstructure:"crowdstrike-client-secret"`
 	Region string `mapstructure:"region"`
 	BaseUrl string `mapstructure:"base-url"`
-	CrowdstrikeIngestRiskScores bool `mapstructure:"crowdstrike-ingest-risk-scores"`
-	CrowdstrikeDetectShadowMcp bool `mapstructure:"crowdstrike-detect-shadow-mcp"`
 	CrowdstrikeIngestPasswordRisk bool `mapstructure:"crowdstrike-ingest-password-risk"`
-	CrowdstrikeDetectAiTools bool `mapstructure:"crowdstrike-detect-ai-tools"`
 }
 
 func (c *Crowdstrike) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,6 +53,14 @@ var (
 			"Off by default; uses the same Identity Protection scopes as risk score ingestion."),
 		field.WithDefaultValue(false),
 	)
+	DetectAIToolsField = field.BoolField(
+		"crowdstrike-detect-ai-tools",
+		field.WithDisplayName("Detect AI coding tools"),
+		field.WithDescription("Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and "+
+			"similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the "+
+			"Alerts read scope."),
+		field.WithDefaultValue(false),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
@@ -64,6 +72,7 @@ var (
 		IngestRiskScoresField,
 		DetectShadowMCPField,
 		IngestPasswordRiskField,
+		DetectAIToolsField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,6 +31,20 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
+	IngestRiskScoresField = field.BoolField(
+		"crowdstrike-ingest-risk-scores",
+		field.WithDisplayName("Ingest identity risk scores"),
+		field.WithDescription("Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors "+
+			"as security insights on identities. Off by default; requires the Identity Protection scopes."),
+		field.WithDefaultValue(false),
+	)
+	DetectShadowMCPField = field.BoolField(
+		"crowdstrike-detect-shadow-mcp",
+		field.WithDisplayName("Detect shadow MCP servers"),
+		field.WithDescription("Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint "+
+			"users that ran them, correlated to identities. Off by default; requires the Alerts read scope."),
+		field.WithDefaultValue(false),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
@@ -39,6 +53,8 @@ var (
 		ClientSecretField,
 		RegionField,
 		BaseURLField,
+		IngestRiskScoresField,
+		DetectShadowMCPField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,14 @@ var (
 			"users that ran them, correlated to identities. Off by default; requires the Alerts read scope."),
 		field.WithDefaultValue(false),
 	)
+	IngestPasswordRiskField = field.BoolField(
+		"crowdstrike-ingest-password-risk",
+		field.WithDisplayName("Ingest identity password risk"),
+		field.WithDescription("Opt-in. When enabled, surface Identity Protection password risk on identity insights — a compromised "+
+			"(exposed) password as an EXPOSED_PASSWORD risk factor and a weak password as a WEAK_PASSWORD risk factor. "+
+			"Off by default; uses the same Identity Protection scopes as risk score ingestion."),
+		field.WithDefaultValue(false),
+	)
 
 	// ConfigurationFields defines the external configuration required for the
 	// connector to run.
@@ -55,6 +63,7 @@ var (
 		BaseURLField,
 		IngestRiskScoresField,
 		DetectShadowMCPField,
+		IngestPasswordRiskField,
 	}
 )
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,9 +34,9 @@ var (
 	IngestRiskScoresField = field.BoolField(
 		"crowdstrike-ingest-risk-scores",
 		field.WithDisplayName("Ingest identity risk scores"),
-		field.WithDescription("Opt-in (early access). When enabled, sync Falcon Identity Protection risk scores and risk factors "+
-			"as security insights on identities. Off by default; requires the Identity Protection scopes."),
-		field.WithDefaultValue(false),
+		field.WithDescription("On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as "+
+			"security insights on identities; requires the Identity Protection scopes. Turn off to disable."),
+		field.WithDefaultValue(true),
 	)
 	DetectShadowMCPField = field.BoolField(
 		"crowdstrike-detect-shadow-mcp",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,34 +31,14 @@ var (
 		field.WithHidden(true),
 		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
-	IngestRiskScoresField = field.BoolField(
-		"crowdstrike-ingest-risk-scores",
-		field.WithDisplayName("Ingest identity risk scores"),
-		field.WithDescription("On by default (early access). Syncs Falcon Identity Protection risk scores and risk factors as "+
-			"security insights on identities; requires the Identity Protection scopes. Turn off to disable."),
-		field.WithDefaultValue(true),
-	)
-	DetectShadowMCPField = field.BoolField(
-		"crowdstrike-detect-shadow-mcp",
-		field.WithDisplayName("Detect shadow MCP servers"),
-		field.WithDescription("Opt-in. When enabled, scan EDR detections for shadow MCP servers and sync them — with the endpoint "+
-			"users that ran them, correlated to identities. Off by default; requires the Alerts read scope."),
-		field.WithDefaultValue(false),
-	)
+	// Password risk is an enrichment on security_insight rows (non-destructive filter),
+	// not a resource-type on/off switch. Optional types are gated by C1 OptInRequired.
 	IngestPasswordRiskField = field.BoolField(
 		"crowdstrike-ingest-password-risk",
 		field.WithDisplayName("Ingest identity password risk"),
 		field.WithDescription("Opt-in. When enabled, surface Identity Protection password risk on identity insights — a compromised "+
 			"(exposed) password as an EXPOSED_PASSWORD risk factor and a weak password as a WEAK_PASSWORD risk factor. "+
 			"Off by default; uses the same Identity Protection scopes as risk score ingestion."),
-		field.WithDefaultValue(false),
-	)
-	DetectAIToolsField = field.BoolField(
-		"crowdstrike-detect-ai-tools",
-		field.WithDisplayName("Detect AI coding tools"),
-		field.WithDescription("Opt-in. When enabled, scan EDR detections for AI coding tools (Claude Code, Cursor, codex, and "+
-			"similar) and sync them as an inventory correlated to the identities that ran them. Off by default; requires the "+
-			"Alerts read scope."),
 		field.WithDefaultValue(false),
 	)
 
@@ -69,10 +49,7 @@ var (
 		ClientSecretField,
 		RegionField,
 		BaseURLField,
-		IngestRiskScoresField,
-		DetectShadowMCPField,
 		IngestPasswordRiskField,
-		DetectAIToolsField,
 	}
 )
 

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -146,16 +146,16 @@ func (a *aiToolResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 // List scans the shared EDR detection snapshot for AI-tool activity, correlates each to
 // an identity, and returns one ai_tool resource per unique (host, user, tool).
 func (a *aiToolResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	dets, err := a.src.detections(ctx, opts.SyncID)
+	dets, detRL, err := a.src.detections(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to fetch detections: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "ai_tool list: failed to fetch detections")
 	}
 	if len(dets) == 0 {
-		return nil, &rs.SyncOpResults{}, nil
+		return nil, &rs.SyncOpResults{Annotations: WithRateLimitAnnotations(detRL)}, nil
 	}
-	idIndex, err := a.src.identityIndex(ctx, opts.SyncID)
+	idIndex, idxRL, err := a.src.identityIndex(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to build identity index: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "ai_tool list: failed to build identity index")
 	}
 
 	instances := buildAIToolInstances(dets)
@@ -167,7 +167,8 @@ func (a *aiToolResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs
 		}
 		resources = append(resources, res)
 	}
-	return resources, &rs.SyncOpResults{}, nil
+	annos := WithRateLimitAnnotations(detRL, idxRL)
+	return resources, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func (a *aiToolResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -36,16 +36,35 @@ type harnessEntry struct {
 // package names (@vendor/tool) or path-qualified executables rather than bare words, to
 // keep common English tokens (e.g. "gemini", "copilot") from matching unrelated
 // processes. This is not meant to be exhaustive — it covers the popular harnesses.
+// cmdToken matches a bare CLI name only where a real invocation puts it: at the start
+// of the command line, right after a path separator (an installed binary), or after a
+// "-m " / "-m=" Python module flag — and only when it ends the token (end-of-string or
+// whitespace/quote). This deliberately rejects the name appearing mid-prose ("run the
+// codex"), as a substring of a longer word, or as a file with an extension
+// ("aider.sh", "Copilot.exe"), which is where bare \bword\b matching produces false
+// positives. %s is the tool name (already regex-safe here).
+func cmdToken(name string) string {
+	return `(^|[\\/]|-m[= ])` + name + `($|[\s"'])`
+}
+
 var harnessCatalog = []harnessEntry{
+	// Claude Code always runs as node against its package path, so match that (works on
+	// every OS); listed before Claude Desktop so the CLI never falls through to it.
 	{"Claude Code", "Anthropic", harnessKindCLI, regexp.MustCompile(`(?i)(@anthropic-ai[\\/]claude-code|claude-code)`)},
-	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|[\\/]claude\.exe)`)},
-	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|cursor-agent|[\\/]cursor-tunnel)`)},
-	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.exe|\bwindsurf\b)`)},
-	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|[\\/]codex\.(exe|cmd|js))`)},
+	// Claude Desktop: Windows AnthropicClaude\...\Claude.exe, macOS Claude.app bundle.
+	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|claude\.app|[\\/]claude\.exe)`)},
+	// Cursor / Windsurf: Windows .exe, macOS .app, plus Cursor's agent/tunnel CLIs. Bare
+	// "cursor" is intentionally NOT matched (collides with SQL cursors); Windsurf's name
+	// is distinctive enough to token-match its bare binary (Linux AppImage).
+	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|[\\/]cursor\.app|cursor-agent|[\\/]cursor-tunnel)`)},
+	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.(exe|app)|` + cmdToken("windsurf") + `)`)},
+	// CLIs: match the npm scope/package form AND the bare installed binary (Homebrew /
+	// curl installs invoke it as just "codex", "copilot", etc.).
+	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|` + cmdToken("codex") + `)`)},
 	{"Gemini CLI", "Google", harnessKindCLI, regexp.MustCompile(`(?i)(@google[\\/]gemini-cli|gemini-cli)`)},
-	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli)`)},
-	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)\bopencode\b`)},
-	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)\baider\b`)},
+	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli|` + cmdToken("copilot") + `)`)},
+	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)` + cmdToken("opencode"))},
+	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)` + cmdToken("aider"))},
 }
 
 // classifyHarness returns the AI tool a command line belongs to, or nil if none match.

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -1,0 +1,232 @@
+package connector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+// AI coding tool ("harness") categories.
+const (
+	harnessKindCLI     = "cli"     // terminal agent (Claude Code, codex, aider, …)
+	harnessKindDesktop = "desktop" // standalone desktop app (Claude Desktop)
+	harnessKindIDE     = "ide"     // AI-native editor (Cursor, Windsurf)
+)
+
+// harnessEntry describes one recognizable AI coding tool and the command-line pattern
+// that identifies it. The pattern is matched against process-creation command lines
+// surfaced by the Alerts API (the same shared scan shadow-MCP detection reads).
+type harnessEntry struct {
+	name    string
+	vendor  string
+	kind    string
+	pattern *regexp.Regexp
+}
+
+// harnessCatalog is the ordered list of AI coding tools we recognize. Order matters:
+// classifyHarness returns the first match, so more specific tools come before broader
+// ones (e.g. Claude Code before Claude Desktop). Patterns are deliberately anchored on
+// package names (@vendor/tool) or path-qualified executables rather than bare words, to
+// keep common English tokens (e.g. "gemini", "copilot") from matching unrelated
+// processes. This is not meant to be exhaustive — it covers the popular harnesses.
+var harnessCatalog = []harnessEntry{
+	{"Claude Code", "Anthropic", harnessKindCLI, regexp.MustCompile(`(?i)(@anthropic-ai[\\/]claude-code|claude-code)`)},
+	{"Claude Desktop", "Anthropic", harnessKindDesktop, regexp.MustCompile(`(?i)(anthropicclaude|[\\/]claude\.exe)`)},
+	{"Cursor", "Anysphere", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]cursor\.exe|cursor-agent|[\\/]cursor-tunnel)`)},
+	{"Windsurf", "Codeium", harnessKindIDE, regexp.MustCompile(`(?i)([\\/]windsurf\.exe|\bwindsurf\b)`)},
+	{"Codex CLI", "OpenAI", harnessKindCLI, regexp.MustCompile(`(?i)(@openai[\\/]codex|codex-cli|[\\/]codex\.(exe|cmd|js))`)},
+	{"Gemini CLI", "Google", harnessKindCLI, regexp.MustCompile(`(?i)(@google[\\/]gemini-cli|gemini-cli)`)},
+	{"GitHub Copilot CLI", "GitHub", harnessKindCLI, regexp.MustCompile(`(?i)(@github[\\/]copilot|copilot-cli)`)},
+	{"opencode", "opencode", harnessKindCLI, regexp.MustCompile(`(?i)\bopencode\b`)},
+	{"Aider", "Aider", harnessKindCLI, regexp.MustCompile(`(?i)\baider\b`)},
+}
+
+// classifyHarness returns the AI tool a command line belongs to, or nil if none match.
+func classifyHarness(cmdline string) *harnessEntry {
+	for i := range harnessCatalog {
+		if harnessCatalog[i].pattern.MatchString(cmdline) {
+			return &harnessCatalog[i]
+		}
+	}
+	return nil
+}
+
+// matchesHarness reports whether a command line names a known AI coding tool. It is used
+// by the shared Alerts scan to keep harness detections alongside shadow-MCP ones.
+func matchesHarness(cmdline string) bool {
+	return classifyHarness(cmdline) != nil
+}
+
+// aiToolInstance is a deduplicated (host, user, tool) AI-tool observation. A tool
+// surfaces under many command-line spellings across the process tree; we collapse them
+// per logical tool and keep the earliest sighting plus the cleanest sample command line.
+type aiToolInstance struct {
+	det         mcpDetection
+	entry       *harnessEntry
+	bestCmdline string
+	count       int
+}
+
+// objectID is the stable ai_tool resource ID: sha256(aid|user|tool) — the same fields
+// buildAIToolInstances dedups on — so it is stable across syncs and command-line
+// spellings.
+func (inst *aiToolInstance) objectID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName), inst.entry.name}, "|")))
+	return "ai-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// buildAIToolInstances deduplicates harness detections into unique (host, user, tool)
+// instances, keeping the earliest timestamp and shortest sample command line.
+func buildAIToolInstances(dets []mcpDetection) map[string]*aiToolInstance {
+	instances := map[string]*aiToolInstance{}
+	for _, d := range dets {
+		if d.AID == "" || d.UserName == "" {
+			continue // unattributable — avoid collapsing distinct hosts/users into one id
+		}
+		entry := classifyHarness(d.CommandLine)
+		if entry == nil {
+			continue
+		}
+		key := strings.Join([]string{d.AID, strings.ToLower(d.UserName), entry.name}, "|")
+		inst, seen := instances[key]
+		if !seen {
+			instances[key] = &aiToolInstance{det: d, entry: entry, bestCmdline: d.CommandLine, count: 1}
+			continue
+		}
+		inst.count++
+		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
+			inst.det.Timestamp = d.Timestamp
+		}
+		if len(d.CommandLine) < len(inst.bestCmdline) {
+			inst.bestCmdline = d.CommandLine
+		}
+	}
+	return instances
+}
+
+// aiToolResourceType syncs AI coding tools ("harnesses" — Claude Code, Cursor, codex,
+// etc.) observed running on endpoints via CrowdStrike EDR detections, correlating each
+// to the identity that ran it. It is an inventory/governance signal (which identities
+// use which AI tools on which hosts), distinct from the shadow-MCP finding.
+type aiToolResourceType struct {
+	resourceType *v2.ResourceType
+	src          *mcpSource
+	// enabled gates AI-tool inventory. The shared source may still scan for shadow-MCP;
+	// this flag decides whether ai_tool resources are emitted.
+	enabled bool
+}
+
+func (a *aiToolResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return a.resourceType
+}
+
+// List scans the shared EDR detection snapshot for AI-tool activity, correlates each to
+// an identity, and returns one ai_tool resource per unique (host, user, tool).
+func (a *aiToolResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !a.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	dets, err := a.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	idIndex, err := a.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to build identity index: %w", err)
+	}
+
+	instances := buildAIToolInstances(dets)
+	resources := make([]*v2.Resource, 0, len(instances))
+	for _, inst := range instances {
+		res, err := aiToolResource(inst, resolveIdentity(idIndex, inst.det.UserName))
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build ai_tool resource: %w", err)
+		}
+		resources = append(resources, res)
+	}
+	return resources, &rs.SyncOpResults{}, nil
+}
+
+func (a *aiToolResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (a *aiToolResourceType) Grants(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// aiToolResource builds an ai_tool resource: an App-trait profile carrying the tool +
+// endpoint + resolved-identity metadata, plus a low-severity security-insight annotation
+// binding the observation to the identity (when one resolves) so it surfaces in c1's
+// identity view as governance visibility rather than a high-severity finding.
+func aiToolResource(inst *aiToolInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+	e := inst.entry
+
+	displayName := fmt.Sprintf("AI Tool: %s @ %s", e.name, d.Hostname)
+	if d.UserName != "" {
+		displayName = fmt.Sprintf("%s (%s)", displayName, d.UserName)
+	}
+
+	profile := map[string]interface{}{
+		"tool":                e.name,
+		"vendor":              e.vendor,
+		"kind":                e.kind,
+		"endpoint_user":       d.UserName,
+		"host":                d.Hostname,
+		"aid":                 d.AID,
+		"local_ip":            d.LocalIP,
+		"sample_command_line": inst.bestCmdline,
+		"detection_count":     inst.count,
+		"ioa_rule":            d.IOARuleName,
+		"falcon_link":         d.FalconLink,
+	}
+	if !d.Timestamp.IsZero() {
+		profile["first_seen"] = d.Timestamp.UTC().Format(time.RFC3339)
+	}
+	if id != nil {
+		profile["identity_email"] = id.email
+		profile["identity_external_id"] = id.externalID
+		profile["identity_display_name"] = id.displayName
+	}
+
+	opts := []rs.ResourceOption{
+		rs.WithAppTrait(rs.WithAppProfile(profile)),
+	}
+
+	// Bind the observation to the identity as a low-severity insight so it associates
+	// in c1's identity view. This is inventory/visibility, not a threat — hence "Low".
+	if id != nil && id.externalID != "" {
+		issueVal := fmt.Sprintf("AI coding tool '%s' (%s, %s) in use on %s by %s",
+			e.name, e.vendor, e.kind, d.Hostname, d.UserName)
+		insightOpts := []rs.SecurityInsightTraitOption{
+			rs.WithIssue(issueVal),
+			rs.WithIssueSeverity("Low"),
+			rs.WithInsightAppUserTarget(id.email, id.externalID),
+		}
+		if !d.Timestamp.IsZero() {
+			insightOpts = append(insightOpts, rs.WithInsightObservedAt(d.Timestamp))
+		}
+		insight, err := rs.NewSecurityInsightTrait(insightOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build security insight trait: %w", err)
+		}
+		opts = append(opts, rs.WithAnnotation(insight))
+	}
+
+	return rs.NewResource(displayName, resourceTypeAITool, inst.objectID(), opts...)
+}
+
+func aiToolBuilder(src *mcpSource, enabled bool) *aiToolResourceType {
+	return &aiToolResourceType{resourceType: resourceTypeAITool, src: src, enabled: enabled}
+}

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -215,7 +215,8 @@ func aiToolResource(inst *aiToolInstance, id *resolvedIdentity) (*v2.Resource, e
 	}
 
 	opts := []rs.ResourceOption{
-		rs.WithAppTrait(rs.WithAppProfile(profile)),
+		rs.WithAppTrait(),
+		rs.WithResourceProfile(profile),
 	}
 
 	// Bind the observation to the identity as a low-severity insight so it associates

--- a/pkg/connector/ai_tool.go
+++ b/pkg/connector/ai_tool.go
@@ -137,9 +137,6 @@ func buildAIToolInstances(dets []mcpDetection) map[string]*aiToolInstance {
 type aiToolResourceType struct {
 	resourceType *v2.ResourceType
 	src          *mcpSource
-	// enabled gates AI-tool inventory. The shared source may still scan for shadow-MCP;
-	// this flag decides whether ai_tool resources are emitted.
-	enabled bool
 }
 
 func (a *aiToolResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -149,9 +146,6 @@ func (a *aiToolResourceType) ResourceType(_ context.Context) *v2.ResourceType {
 // List scans the shared EDR detection snapshot for AI-tool activity, correlates each to
 // an identity, and returns one ai_tool resource per unique (host, user, tool).
 func (a *aiToolResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	if !a.enabled {
-		return nil, &rs.SyncOpResults{}, nil
-	}
 	dets, err := a.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: ai_tool list: failed to fetch detections: %w", err)
@@ -246,6 +240,6 @@ func aiToolResource(inst *aiToolInstance, id *resolvedIdentity) (*v2.Resource, e
 	return rs.NewResource(displayName, resourceTypeAITool, inst.objectID(), opts...)
 }
 
-func aiToolBuilder(src *mcpSource, enabled bool) *aiToolResourceType {
-	return &aiToolResourceType{resourceType: resourceTypeAITool, src: src, enabled: enabled}
+func aiToolBuilder(src *mcpSource) *aiToolResourceType {
+	return &aiToolResourceType{resourceType: resourceTypeAITool, src: src}
 }

--- a/pkg/connector/ai_tool_test.go
+++ b/pkg/connector/ai_tool_test.go
@@ -1,11 +1,8 @@
 package connector
 
 import (
-	"context"
 	"testing"
 	"time"
-
-	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
 func TestClassifyHarness(t *testing.T) {
@@ -117,19 +114,6 @@ func TestBuildAIToolInstances(t *testing.T) {
 	}
 	if len(cc.objectID()) == 0 || cc.objectID()[:3] != "ai-" {
 		t.Errorf("objectID = %q, want ai- prefix", cc.objectID())
-	}
-}
-
-// A disabled ai_tool syncer must emit nothing and must not touch its source (so a nil
-// source is safe) — this is the opt-in, no-API-call guarantee.
-func TestAIToolDisabledEmitsNothing(t *testing.T) {
-	rt := aiToolBuilder(nil, false)
-	res, _, err := rt.List(context.Background(), nil, rs.SyncOpAttrs{})
-	if err != nil {
-		t.Fatalf("List returned error: %v", err)
-	}
-	if len(res) != 0 {
-		t.Fatalf("disabled List returned %d resources, want 0", len(res))
 	}
 }
 

--- a/pkg/connector/ai_tool_test.go
+++ b/pkg/connector/ai_tool_test.go
@@ -19,7 +19,7 @@ func TestClassifyHarness(t *testing.T) {
 		{"claude code shim", "claude-code --print hello", "Claude Code"},
 		// Claude Desktop (Electron app).
 		{"claude desktop exe", `C:\Users\a\AppData\Local\AnthropicClaude\app-0.1\Claude.exe --type=renderer`, "Claude Desktop"},
-		{"claude desktop path only", `/Applications/Claude.app/Contents/MacOS/claude.exe`, "Claude Desktop"},
+		{"claude desktop macos bundle", `/Applications/Claude.app/Contents/MacOS/Claude`, "Claude Desktop"},
 		// IDEs.
 		{"cursor exe", `C:\Users\a\AppData\Local\Programs\cursor\Cursor.exe`, "Cursor"},
 		{"cursor agent cli", "cursor-agent --resume", "Cursor"},
@@ -31,13 +31,21 @@ func TestClassifyHarness(t *testing.T) {
 		{"gemini cli scope", "npx @google/gemini-cli chat", "Gemini CLI"},
 		{"github copilot cli", "npx @github/copilot suggest", "GitHub Copilot CLI"},
 		{"opencode", "/usr/local/bin/opencode", "opencode"},
-		{"aider python", "python -m aider --model gpt-4o", "Aider"},
+		{"aider python module", "python -m aider --model gpt-4o", "Aider"},
+		// Homebrew / curl installs invoke the CLI as a bare binary (no npm scope).
+		{"codex homebrew binary", "/opt/homebrew/bin/codex --model o3", "Codex CLI"},
+		{"copilot homebrew binary", "/usr/local/bin/copilot suggest", "GitHub Copilot CLI"},
+		{"aider console script", "/usr/local/bin/aider --model gpt-4o", "Aider"},
 
 		// Negatives — guard the bare-word / broad patterns against false positives.
 		{"shadow mcp server is not a harness", "npx -y @modelcontextprotocol/server-filesystem /tmp", ""},
 		{"bare codex word does not match", "run the codex please", ""},
+		{"codex as a filename does not match", "7z x /downloads/game.CODEX.iso", ""},
 		{"bare gemini word does not match", "gemini horoscope generator", ""},
 		{"bare copilot word does not match", "microsoft copilot app", ""},
+		{"windows copilot app is not the cli", `C:\Windows\SystemApps\MicrosoftWindows.Client.Copilot\Copilot.exe`, ""},
+		{"aider unrelated wrapper script does not match", "aider.sh deploy prod", ""},
+		{"opencode as a substring does not match", "tar -xf opencode-backup.tar", ""},
 		{"plain node app", "node /srv/app/index.js", ""},
 		{"db cursor usage", "psql -c 'DECLARE cur CURSOR FOR SELECT 1'", ""},
 	}

--- a/pkg/connector/ai_tool_test.go
+++ b/pkg/connector/ai_tool_test.go
@@ -1,0 +1,134 @@
+package connector
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+)
+
+func TestClassifyHarness(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmdline  string
+		wantTool string // "" means expect no match
+	}{
+		// Claude Code (must win over Claude Desktop when the package name is present).
+		{"claude code npm package", `node C:\Users\a\AppData\Roaming\npm\node_modules\@anthropic-ai\claude-code\cli.js`, "Claude Code"},
+		{"claude code shim", "claude-code --print hello", "Claude Code"},
+		// Claude Desktop (Electron app).
+		{"claude desktop exe", `C:\Users\a\AppData\Local\AnthropicClaude\app-0.1\Claude.exe --type=renderer`, "Claude Desktop"},
+		{"claude desktop path only", `/Applications/Claude.app/Contents/MacOS/claude.exe`, "Claude Desktop"},
+		// IDEs.
+		{"cursor exe", `C:\Users\a\AppData\Local\Programs\cursor\Cursor.exe`, "Cursor"},
+		{"cursor agent cli", "cursor-agent --resume", "Cursor"},
+		{"windsurf exe", `C:\Program Files\Windsurf\Windsurf.exe`, "Windsurf"},
+		{"windsurf word", "/usr/local/bin/windsurf", "Windsurf"},
+		// CLI harnesses.
+		{"codex npm scope", `node /home/u/.npm/_npx/x/node_modules/@openai/codex/bin.js`, "Codex CLI"},
+		{"codex cli suffix", "openai-codex-cli run", "Codex CLI"},
+		{"gemini cli scope", "npx @google/gemini-cli chat", "Gemini CLI"},
+		{"github copilot cli", "npx @github/copilot suggest", "GitHub Copilot CLI"},
+		{"opencode", "/usr/local/bin/opencode", "opencode"},
+		{"aider python", "python -m aider --model gpt-4o", "Aider"},
+
+		// Negatives — guard the bare-word / broad patterns against false positives.
+		{"shadow mcp server is not a harness", "npx -y @modelcontextprotocol/server-filesystem /tmp", ""},
+		{"bare codex word does not match", "run the codex please", ""},
+		{"bare gemini word does not match", "gemini horoscope generator", ""},
+		{"bare copilot word does not match", "microsoft copilot app", ""},
+		{"plain node app", "node /srv/app/index.js", ""},
+		{"db cursor usage", "psql -c 'DECLARE cur CURSOR FOR SELECT 1'", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyHarness(tt.cmdline)
+			if tt.wantTool == "" {
+				if got != nil {
+					t.Fatalf("classifyHarness(%q) = %q, want no match", tt.cmdline, got.name)
+				}
+				if matchesHarness(tt.cmdline) {
+					t.Fatalf("matchesHarness(%q) = true, want false", tt.cmdline)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("classifyHarness(%q) = nil, want %q", tt.cmdline, tt.wantTool)
+			}
+			if got.name != tt.wantTool {
+				t.Fatalf("classifyHarness(%q) = %q, want %q", tt.cmdline, got.name, tt.wantTool)
+			}
+			if !matchesHarness(tt.cmdline) {
+				t.Fatalf("matchesHarness(%q) = false, want true", tt.cmdline)
+			}
+		})
+	}
+}
+
+func TestBuildAIToolInstances(t *testing.T) {
+	early := time.Date(2026, 1, 2, 8, 0, 0, 0, time.UTC)
+	late := early.Add(time.Hour)
+	dets := []mcpDetection{
+		// Two spellings of the same tool for the same (host, user) collapse to one, keep
+		// the earliest timestamp and the shortest command line.
+		{AID: "aid1", UserName: "Alice", CommandLine: "node .../@anthropic-ai/claude-code/cli.js --long-flags", Timestamp: late},
+		{AID: "aid1", UserName: "alice", CommandLine: "claude-code", Timestamp: early},
+		// Same tool, different host → distinct instance.
+		{AID: "aid2", UserName: "alice", CommandLine: "claude-code", Timestamp: late},
+		// Different tool, same host/user → distinct instance.
+		{AID: "aid1", UserName: "alice", CommandLine: `C:\cursor\Cursor.exe`, Timestamp: late},
+		// Non-harness rows are ignored.
+		{AID: "aid1", UserName: "alice", CommandLine: "npx @modelcontextprotocol/server-git", Timestamp: late},
+		// Unattributable rows are skipped.
+		{AID: "", UserName: "bob", CommandLine: "claude-code", Timestamp: late},
+	}
+	got := buildAIToolInstances(dets)
+	if len(got) != 3 {
+		t.Fatalf("got %d instances, want 3: %+v", len(got), keysOf(got))
+	}
+
+	// The aid1/alice/Claude Code instance should have collapsed both spellings.
+	var cc *aiToolInstance
+	for _, inst := range got {
+		if inst.det.AID == "aid1" && inst.entry.name == "Claude Code" {
+			cc = inst
+		}
+	}
+	if cc == nil {
+		t.Fatal("missing aid1 Claude Code instance")
+	}
+	if cc.count != 2 {
+		t.Errorf("count = %d, want 2", cc.count)
+	}
+	if !cc.det.Timestamp.Equal(early) {
+		t.Errorf("timestamp = %v, want earliest %v", cc.det.Timestamp, early)
+	}
+	if cc.bestCmdline != "claude-code" {
+		t.Errorf("bestCmdline = %q, want shortest %q", cc.bestCmdline, "claude-code")
+	}
+	if len(cc.objectID()) == 0 || cc.objectID()[:3] != "ai-" {
+		t.Errorf("objectID = %q, want ai- prefix", cc.objectID())
+	}
+}
+
+// A disabled ai_tool syncer must emit nothing and must not touch its source (so a nil
+// source is safe) — this is the opt-in, no-API-call guarantee.
+func TestAIToolDisabledEmitsNothing(t *testing.T) {
+	rt := aiToolBuilder(nil, false)
+	res, _, err := rt.List(context.Background(), nil, rs.SyncOpAttrs{})
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Fatalf("disabled List returned %d resources, want 0", len(res))
+	}
+}
+
+func keysOf(m map[string]*aiToolInstance) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -17,21 +17,23 @@ import (
 )
 
 type Connector struct {
-	client       *fClient.CrowdStrikeAPISpecification
-	clientId     string
-	clientSecret string
-	host         string
+	client           *fClient.CrowdStrikeAPISpecification
+	clientId         string
+	clientSecret     string
+	host             string
+	ingestRiskScores bool
+	detectShadowMCP  bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
 	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
 	// a single per-sync detection snapshot + identity index (consistent grants, no
 	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host)
+	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host, o.detectShadowMCP)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host),
+		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host, o.ingestRiskScores),
 		mcpServerBuilder(o.client, mcpSrc),
 		endpointUserBuilder(mcpSrc),
 	}
@@ -152,9 +154,11 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 	}
 
 	return &Connector{
-		client:       client,
-		clientId:     cc.CrowdstrikeClientId,
-		clientSecret: cc.CrowdstrikeClientSecret,
-		host:         host,
+		client:           client,
+		clientId:         cc.CrowdstrikeClientId,
+		clientSecret:     cc.CrowdstrikeClientSecret,
+		host:             host,
+		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
+		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,19 +24,22 @@ type Connector struct {
 	ingestRiskScores   bool
 	detectShadowMCP    bool
 	ingestPasswordRisk bool
+	detectAITools      bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
-	// a single per-sync detection snapshot + identity index (consistent grants, no
-	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP)
+	// One shared EDR-detection data source feeds the mcp_server, endpoint_user, and
+	// ai_tool syncers off a single per-sync snapshot + identity index (consistent
+	// grants, no redundant Alerts / Identity-Protection calls). The source scans when
+	// either detection capability is on; each syncer decides what it emits.
+	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP || o.detectAITools)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
 		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores, o.ingestPasswordRisk),
-		mcpServerBuilder(o.client, mcpSrc),
-		endpointUserBuilder(mcpSrc),
+		mcpServerBuilder(o.client, mcpSrc, o.detectShadowMCP),
+		endpointUserBuilder(mcpSrc, o.detectShadowMCP),
+		aiToolBuilder(mcpSrc, o.detectAITools),
 	}
 }
 
@@ -178,5 +181,6 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		ingestRiskScores:   cc.CrowdstrikeIngestRiskScores,
 		detectShadowMCP:    cc.CrowdstrikeDetectShadowMcp,
 		ingestPasswordRisk: cc.CrowdstrikeIngestPasswordRisk,
+		detectAITools:      cc.CrowdstrikeDetectAiTools,
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -18,11 +18,12 @@ import (
 )
 
 type Connector struct {
-	client           *fClient.CrowdStrikeAPISpecification
-	httpClient       *uhttp.BaseHttpClient
-	host             string
-	ingestRiskScores bool
-	detectShadowMCP  bool
+	client             *fClient.CrowdStrikeAPISpecification
+	httpClient         *uhttp.BaseHttpClient
+	host               string
+	ingestRiskScores   bool
+	detectShadowMCP    bool
+	ingestPasswordRisk bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
@@ -33,7 +34,7 @@ func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores),
+		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores, o.ingestPasswordRisk),
 		mcpServerBuilder(o.client, mcpSrc),
 		endpointUserBuilder(mcpSrc),
 	}
@@ -171,10 +172,11 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 	}
 
 	return &Connector{
-		client:           client,
-		httpClient:       httpClient,
-		host:             host,
-		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
-		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,
+		client:             client,
+		httpClient:         httpClient,
+		host:               host,
+		ingestRiskScores:   cc.CrowdstrikeIngestRiskScores,
+		detectShadowMCP:    cc.CrowdstrikeDetectShadowMcp,
+		ingestPasswordRisk: cc.CrowdstrikeIngestPasswordRisk,
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	cfg "github.com/conductorone/baton-crowdstrike/pkg/config"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
@@ -18,8 +19,7 @@ import (
 
 type Connector struct {
 	client           *fClient.CrowdStrikeAPISpecification
-	clientId         string
-	clientSecret     string
+	httpClient       *uhttp.BaseHttpClient
 	host             string
 	ingestRiskScores bool
 	detectShadowMCP  bool
@@ -29,11 +29,11 @@ func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
 	// a single per-sync detection snapshot + identity index (consistent grants, no
 	// redundant Alerts / Identity-Protection calls).
-	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host, o.detectShadowMCP)
+	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host, o.ingestRiskScores),
+		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores),
 		mcpServerBuilder(o.client, mcpSrc),
 		endpointUserBuilder(mcpSrc),
 	}
@@ -153,10 +153,26 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		host = cc.BaseUrl
 	}
 
+	// The Identity Protection (GraphQL) and Alerts APIs share the same OAuth2
+	// client-credentials grant against the same host, so one uhttp base client
+	// serves both.
+	tokenURL, err := url.Parse("https://" + host + "/oauth2/token")
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse oauth2 token url: %w", err)
+	}
+	oauthCreds := uhttp.NewOAuth2ClientCredentials(cc.CrowdstrikeClientId, cc.CrowdstrikeClientSecret, tokenURL, nil)
+	oauthClient, err := oauthCreds.GetClient(ctx, uhttp.WithUserAgent("baton-crowdstrike"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create oauth2 http client: %w", err)
+	}
+	httpClient, err := uhttp.NewBaseHttpClientWithContext(ctx, oauthClient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create base http client: %w", err)
+	}
+
 	return &Connector{
 		client:           client,
-		clientId:         cc.CrowdstrikeClientId,
-		clientSecret:     cc.CrowdstrikeClientSecret,
+		httpClient:       httpClient,
 		host:             host,
 		ingestRiskScores: cc.CrowdstrikeIngestRiskScores,
 		detectShadowMCP:  cc.CrowdstrikeDetectShadowMcp,

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -24,10 +24,16 @@ type Connector struct {
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
+	// One shared MCP data source so the mcp_server and endpoint_user syncers operate on
+	// a single per-sync detection snapshot + identity index (consistent grants, no
+	// redundant Alerts / Identity-Protection calls).
+	mcpSrc := newMCPSource(ctx, o.clientId, o.clientSecret, o.host)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
 		securityInsightBuilder(ctx, o.client, o.clientId, o.clientSecret, o.host),
+		mcpServerBuilder(o.client, mcpSrc),
+		endpointUserBuilder(mcpSrc),
 	}
 }
 

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -21,32 +21,28 @@ type Connector struct {
 	client             *fClient.CrowdStrikeAPISpecification
 	httpClient         *uhttp.BaseHttpClient
 	host               string
-	ingestRiskScores   bool
-	detectShadowMCP    bool
 	ingestPasswordRisk bool
-	detectAITools      bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
-	// One shared EDR-detection data source feeds the mcp_server, endpoint_user, and
-	// ai_tool syncers off a single per-sync snapshot + identity index (consistent
-	// grants, no redundant Alerts / Identity-Protection calls). The source scans when
-	// either detection capability is on; each syncer decides what it emits.
-	mcpSrc := newMCPSource(o.httpClient, o.host, o.detectShadowMCP || o.detectAITools)
+	// Shared EDR-detection snapshot + identity index for mcp_server, endpoint_user, and
+	// ai_tool. Optional types are gated by C1 OptInRequired (not connector config kill
+	// switches) so List always attempts upstream when C1 schedules the type.
+	mcpSrc := newMCPSource(o.httpClient, o.host)
 	return []connectorbuilder.ResourceSyncerV2{
 		userBuilder(o.client),
 		roleBuilder(o.client),
-		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestRiskScores, o.ingestPasswordRisk),
-		mcpServerBuilder(o.client, mcpSrc, o.detectShadowMCP),
-		endpointUserBuilder(mcpSrc, o.detectShadowMCP),
-		aiToolBuilder(mcpSrc, o.detectAITools),
+		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestPasswordRisk),
+		mcpServerBuilder(o.client, mcpSrc),
+		endpointUserBuilder(mcpSrc),
+		aiToolBuilder(mcpSrc),
 	}
 }
 
 func (o *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error) {
 	return &v2.ConnectorMetadata{
 		DisplayName: "CrowdStrike",
-		Description: "Connector syncing CrowdStrike users, roles, and identity risk scores to Baton.",
+		Description: "Connector syncing CrowdStrike users, roles, identity risk scores, optional shadow MCP / AI tool inventory, and endpoint users to Baton.",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
 				"email": {
@@ -178,9 +174,6 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		client:             client,
 		httpClient:         httpClient,
 		host:               host,
-		ingestRiskScores:   cc.CrowdstrikeIngestRiskScores,
-		detectShadowMCP:    cc.CrowdstrikeDetectShadowMcp,
 		ingestPasswordRisk: cc.CrowdstrikeIngestPasswordRisk,
-		detectAITools:      cc.CrowdstrikeDetectAiTools,
 	}, nil, nil
 }

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -256,6 +256,7 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
+	//nolint:gosec // endpoint host derives from the configured CrowdStrike region, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -166,17 +166,16 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
 // IdentityProtectionClient provides methods to interact with CrowdStrike's Identity Protection API.
 type IdentityProtectionClient struct {
 	httpClient *uhttp.BaseHttpClient
-	endpoint   *url.URL
+	host       string
 }
 
 // NewIdentityProtectionClient creates a new Identity Protection client that talks to CrowdStrike's
 // GraphQL API over the given shared uhttp base client (OAuth2 client-credentials, transient-error
 // retries, and rate-limit metadata all handled by uhttp).
 func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string) *IdentityProtectionClient {
-	endpoint, _ := url.Parse("https://" + host + "/identity-protection/combined/graphql/v1")
 	return &IdentityProtectionClient{
 		httpClient: httpClient,
-		endpoint:   endpoint,
+		host:       host,
 	}
 }
 
@@ -196,7 +195,12 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 		Variables: variables,
 	}
 
-	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, c.endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
+	endpoint, err := url.Parse("https://" + c.host + "/identity-protection/combined/graphql/v1")
+	if err != nil {
+		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: invalid identity protection endpoint for host %q: %w", c.host, err)
+	}
+
+	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to create HTTP request: %w", err)
 	}

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -1,16 +1,13 @@
 package connector
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
+	"net/url"
 	"strings"
-	"time"
 
-	"golang.org/x/oauth2/clientcredentials"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 )
 
 // AccountData represents an external account descriptor associated with an identity entity.
@@ -168,61 +165,19 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
 
 // IdentityProtectionClient provides methods to interact with CrowdStrike's Identity Protection API.
 type IdentityProtectionClient struct {
-	httpClient *http.Client
-	endpoint   string
+	httpClient *uhttp.BaseHttpClient
+	endpoint   *url.URL
 }
 
-// NewIdentityProtectionClient creates a new Identity Protection client with OAuth2 authentication.
-func NewIdentityProtectionClient(ctx context.Context, clientID, clientSecret, host string) *IdentityProtectionClient {
-	// Create OAuth2 client credentials config
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-
-	// Create the OAuth2 HTTP client
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
-
-	// Wrap the transport to add user-agent header
-	httpClient.Transport = &identityProtectionTransport{
-		base: httpClient.Transport,
-	}
-
+// NewIdentityProtectionClient creates a new Identity Protection client that talks to CrowdStrike's
+// GraphQL API over the given shared uhttp base client (OAuth2 client-credentials, transient-error
+// retries, and rate-limit metadata all handled by uhttp).
+func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string) *IdentityProtectionClient {
+	endpoint, _ := url.Parse("https://" + host + "/identity-protection/combined/graphql/v1")
 	return &IdentityProtectionClient{
 		httpClient: httpClient,
-		endpoint:   "https://" + host + "/identity-protection/combined/graphql/v1",
+		endpoint:   endpoint,
 	}
-}
-
-// identityProtectionTransport adds custom headers to requests.
-type identityProtectionTransport struct {
-	base http.RoundTripper
-}
-
-func (t *identityProtectionTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("User-Agent", "baton-crowdstrike")
-	if t.base == nil {
-		return http.DefaultTransport.RoundTrip(req)
-	}
-	return t.base.RoundTrip(req)
-}
-
-// RefreshContext updates the OAuth2 context used for token refresh.
-// This should be called before making requests to ensure the token can be refreshed.
-func (c *IdentityProtectionClient) RefreshContext(ctx context.Context, clientID, clientSecret, host string) {
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
-	httpClient.Transport = &identityProtectionTransport{
-		base: httpClient.Transport,
-	}
-	c.httpClient = httpClient
 }
 
 // GetIdentityRiskScores fetches identity risk scores from CrowdStrike Identity Protection.
@@ -241,45 +196,23 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 		Variables: variables,
 	}
 
-	// Create the request body
-	bodyBytes, err := json.Marshal(reqBody)
-	if err != nil {
-		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to marshal GraphQL request: %w", err)
-	}
-
-	// Create the HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(bodyBytes))
+	req, err := c.httpClient.NewRequest(ctx, http.MethodPost, c.endpoint, uhttp.WithJSONBody(reqBody), uhttp.WithAcceptJSONHeader())
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to create HTTP request: %w", err)
 	}
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)
+	var graphQLResp graphQLResponse
+	resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&graphQLResp))
+	if resp == nil {
+		return nil, "", false, RateLimitInfo{}, err
 	}
 	defer resp.Body.Close()
 
-	// Extract rate limit info from response headers
+	// Extract rate limit info from response headers, even on error, so callers can
+	// still surface rate-limit annotations for a failed request.
 	rateLimitInfo := extractRateLimitInfo(resp)
-
-	// Check for error status codes
-	if resp.StatusCode != http.StatusOK {
-		bodyBytes, _ := io.ReadAll(resp.Body)
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: identity protection API returned status %d: %s", resp.StatusCode, string(bodyBytes))
-	}
-
-	// Parse the response body
-	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: failed to read response body: %w", err)
-	}
-
-	var graphQLResp graphQLResponse
-	if err := json.Unmarshal(respBody, &graphQLResp); err != nil {
-		return nil, "", false, rateLimitInfo, fmt.Errorf("baton-crowdstrike: failed to parse GraphQL response: %w", err)
+		return nil, "", false, rateLimitInfo, err
 	}
 
 	// Check for GraphQL errors

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -134,7 +134,19 @@ type graphQLError struct {
 	Message string `json:"message"`
 }
 
-const identityRiskQuery = `
+// passwordAttributesSelection is the account-descriptor sub-selection that fetches
+// password risk. It is injected into each account fragment of the query ONLY when
+// password-risk ingestion is opted in; otherwise the query does not request it and
+// no password attributes are returned.
+const passwordAttributesSelection = `
+          passwordAttributes {
+            exposed
+            strength
+          }`
+
+// identityRiskQueryTmpl is the entities query with a single injection point (%[1]s)
+// in each user account descriptor fragment for the optional password selection.
+const identityRiskQueryTmpl = `
 query GetIdentityRiskScores($first: Int, $after: Cursor) {
   entities(types: [USER], sortKey: PRIMARY_DISPLAY_NAME, first: $first, after: $after) {
     pageInfo {
@@ -156,32 +168,16 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
           objectSid
           samAccountName
           domain
-          objectGuid
-          passwordAttributes {
-            exposed
-            strength
-          }
+          objectGuid%[1]s
         }
         ... on AzureSsoUserAccountDescriptor {
-          dataSourceParticipantIdentifier
-          passwordAttributes {
-            exposed
-            strength
-          }
+          dataSourceParticipantIdentifier%[1]s
         }
         ... on AwsIcSsoUserAccountDescriptorImpl {
-          dataSourceParticipantIdentifier
-          passwordAttributes {
-            exposed
-            strength
-          }
+          dataSourceParticipantIdentifier%[1]s
         }
         ... on SsoUserAccountDescriptorImpl {
-          dataSourceParticipantIdentifier
-          passwordAttributes {
-            exposed
-            strength
-          }
+          dataSourceParticipantIdentifier%[1]s
         }
       }
       ... on UserEntity {
@@ -192,19 +188,34 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
 }
 `
 
+// buildIdentityRiskQuery returns the entities query, including the password risk
+// selection only when password-risk ingestion is opted in.
+func buildIdentityRiskQuery(includePasswordRisk bool) string {
+	sel := ""
+	if includePasswordRisk {
+		sel = passwordAttributesSelection
+	}
+	return fmt.Sprintf(identityRiskQueryTmpl, sel)
+}
+
 // IdentityProtectionClient provides methods to interact with CrowdStrike's Identity Protection API.
 type IdentityProtectionClient struct {
 	httpClient *uhttp.BaseHttpClient
 	host       string
+	// includePasswordRisk gates the optional password-attributes selection in the
+	// entities query (opt-in; off by default).
+	includePasswordRisk bool
 }
 
 // NewIdentityProtectionClient creates a new Identity Protection client that talks to CrowdStrike's
 // GraphQL API over the given shared uhttp base client (OAuth2 client-credentials, transient-error
-// retries, and rate-limit metadata all handled by uhttp).
-func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string) *IdentityProtectionClient {
+// retries, and rate-limit metadata all handled by uhttp). includePasswordRisk opts the entities
+// query into the password-attributes selection.
+func NewIdentityProtectionClient(httpClient *uhttp.BaseHttpClient, host string, includePasswordRisk bool) *IdentityProtectionClient {
 	return &IdentityProtectionClient{
-		httpClient: httpClient,
-		host:       host,
+		httpClient:          httpClient,
+		host:                host,
+		includePasswordRisk: includePasswordRisk,
 	}
 }
 
@@ -220,7 +231,7 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 	}
 
 	reqBody := graphQLRequest{
-		Query:     identityRiskQuery,
+		Query:     buildIdentityRiskQuery(c.includePasswordRisk),
 		Variables: variables,
 	}
 

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -22,6 +22,19 @@ type AccountData struct {
 
 	// Azure AD / AWS IC SSO / Generic SSO fields
 	DataSourceParticipantIdentifier string `json:"dataSourceParticipantIdentifier,omitempty"`
+
+	// PasswordAttributes carries per-account password risk signals (present on user
+	// account descriptors). Nil when the descriptor type does not expose it.
+	PasswordAttributes *PasswordAttributes `json:"passwordAttributes,omitempty"`
+}
+
+// PasswordAttributes captures the password risk signals Identity Protection exposes
+// on a user account descriptor. "Exposed" is CrowdStrike's compromised-credential
+// signal (the password appears in a known breach/exposed set); "Strength" is the
+// PasswordStrength enum (UNKNOWN | WEAK | STRONG).
+type PasswordAttributes struct {
+	Exposed  bool   `json:"exposed"`
+	Strength string `json:"strength"`
 }
 
 // ExternalID returns the best external identifier for this account based on its type.
@@ -144,15 +157,31 @@ query GetIdentityRiskScores($first: Int, $after: Cursor) {
           samAccountName
           domain
           objectGuid
+          passwordAttributes {
+            exposed
+            strength
+          }
         }
         ... on AzureSsoUserAccountDescriptor {
           dataSourceParticipantIdentifier
+          passwordAttributes {
+            exposed
+            strength
+          }
         }
         ... on AwsIcSsoUserAccountDescriptorImpl {
           dataSourceParticipantIdentifier
+          passwordAttributes {
+            exposed
+            strength
+          }
         }
         ... on SsoUserAccountDescriptorImpl {
           dataSourceParticipantIdentifier
+          passwordAttributes {
+            exposed
+            strength
+          }
         }
       }
       ... on UserEntity {

--- a/pkg/connector/identity_protection.go
+++ b/pkg/connector/identity_protection.go
@@ -256,7 +256,6 @@ func (c *IdentityProtectionClient) GetIdentityRiskScores(ctx context.Context, pa
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	//nolint:gosec // endpoint host derives from the configured CrowdStrike region, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, "", false, RateLimitInfo{}, fmt.Errorf("baton-crowdstrike: failed to execute identity protection request: %w", err)

--- a/pkg/connector/identity_protection_test.go
+++ b/pkg/connector/identity_protection_test.go
@@ -1,0 +1,30 @@
+package connector
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildIdentityRiskQuery verifies password-risk ingestion is opt-in: the
+// passwordAttributes selection is present only when explicitly enabled, and the
+// base risk query is intact either way.
+func TestBuildIdentityRiskQuery(t *testing.T) {
+	off := buildIdentityRiskQuery(false)
+	if strings.Contains(off, "passwordAttributes") {
+		t.Errorf("password risk OFF (default): query must not request passwordAttributes:\n%s", off)
+	}
+
+	on := buildIdentityRiskQuery(true)
+	if !strings.Contains(on, "passwordAttributes") {
+		t.Errorf("password risk ON: query must request passwordAttributes:\n%s", on)
+	}
+
+	// The base entities query must be intact regardless of the flag.
+	for _, q := range []string{off, on} {
+		for _, want := range []string{"GetIdentityRiskScores", "riskScore", "riskFactors", "ActiveDirectoryAccountDescriptor"} {
+			if !strings.Contains(q, want) {
+				t.Errorf("query missing base field %q:\n%s", want, q)
+			}
+		}
+	}
+}

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -631,7 +631,8 @@ func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *
 	return &mcpSource{
 		enabled:   enabled,
 		detClient: newMCPDetectionsClient(httpClient, host),
-		ipClient:  NewIdentityProtectionClient(httpClient, host),
+		// Shadow-MCP identity resolution never needs password risk — keep it off.
+		ipClient: NewIdentityProtectionClient(httpClient, host, false),
 	}
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -670,6 +670,11 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 // snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
 // that independent re-fetches would cause. Only the current sync's data is retained.
 type mcpSource struct {
+	// enabled gates shadow-MCP detection. When false (the default), detections and
+	// the identity index are no-ops that make no CrowdStrike API calls, so the
+	// mcp_server / endpoint_user syncers produce nothing — the capability is opt-in.
+	enabled bool
+
 	detClient *mcpDetectionsClient
 	ipClient  *IdentityProtectionClient
 
@@ -680,14 +685,18 @@ type mcpSource struct {
 	idxData map[string]*resolvedIdentity
 }
 
-func newMCPSource(ctx context.Context, clientID, clientSecret, host string) *mcpSource {
+func newMCPSource(ctx context.Context, clientID, clientSecret, host string, enabled bool) *mcpSource {
 	return &mcpSource{
+		enabled:   enabled,
 		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
 		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
 	}
 }
 
 func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
+	if !s.enabled {
+		return nil, nil
+	}
 	s.mu.Lock()
 	if s.detData != nil && s.detSync == syncID {
 		d := s.detData
@@ -706,6 +715,9 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 }
 
 func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
+	if !s.enabled {
+		return map[string]*resolvedIdentity{}, nil
+	}
 	s.mu.Lock()
 	if s.idxData != nil && s.idxSync == syncID {
 		idx := s.idxData

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -28,6 +28,9 @@ import (
 // by the endpoint user that ran the server.
 const mcpRunnerEntitlement = "runner"
 
+// launcherUnknown marks a detection whose command line doesn't name a known launcher.
+const launcherUnknown = "unknown"
+
 // mcpServerAlertLimit is how many recent alerts we pull to scan for shadow-MCP activity.
 const mcpServerAlertLimit = 1000
 
@@ -234,7 +237,7 @@ func buildInstances(dets []mcpDetection) map[string]*mcpServerInstance {
 		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
 			inst.det.Timestamp = d.Timestamp
 		}
-		if inst.launcher == "unknown" && launcher != "unknown" {
+		if inst.launcher == launcherUnknown && launcher != launcherUnknown {
 			inst.launcher = launcher
 			inst.transport = transport
 		}
@@ -422,29 +425,32 @@ func resolveIdentity(index map[string]*resolvedIdentity, userName string) *resol
 	return nil
 }
 
-// parseMCPServer extracts the MCP server identity from a process command line.
-func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok bool) {
+// parseMCPServer extracts the MCP server identity from a process command line,
+// returning (name, package, launcher, transport, matched).
+func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 	match := mcpSignature.FindString(cmdline)
 	if match == "" {
 		return "", "", "", "", false
 	}
 	// A bare .js entrypoint (e.g. mcp-server-fetch.js) and its package name are the same
 	// logical server; drop the extension so they don't split into two resources.
-	match = strings.TrimSuffix(match, ".js")
-	pkg = match
+	pkg := strings.TrimSuffix(match, ".js")
+
 	// Derive a short logical name from the package suffix.
+	var name string
 	switch {
-	case strings.HasPrefix(match, "@modelcontextprotocol/server-"):
-		name = strings.TrimPrefix(match, "@modelcontextprotocol/server-")
-	case strings.HasPrefix(match, "mcp-server-"):
-		name = strings.TrimPrefix(match, "mcp-server-")
-	case strings.HasPrefix(match, "mcp_server_"):
-		name = strings.TrimPrefix(match, "mcp_server_")
+	case strings.HasPrefix(pkg, "@modelcontextprotocol/server-"):
+		name = strings.TrimPrefix(pkg, "@modelcontextprotocol/server-")
+	case strings.HasPrefix(pkg, "mcp-server-"):
+		name = strings.TrimPrefix(pkg, "mcp-server-")
+	case strings.HasPrefix(pkg, "mcp_server_"):
+		name = strings.TrimPrefix(pkg, "mcp_server_")
 	default:
-		name = match
+		name = pkg
 	}
 
 	lc := strings.ToLower(cmdline)
+	launcher := launcherUnknown
 	switch {
 	case strings.Contains(lc, "npx"):
 		launcher = "npx"
@@ -454,11 +460,9 @@ func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok b
 		launcher = "python"
 	case strings.Contains(lc, "node"):
 		launcher = "node"
-	default:
-		launcher = "unknown"
 	}
 
-	transport = "stdio"
+	transport := "stdio"
 	if strings.Contains(lc, "--sse") || strings.Contains(lc, "transport sse") || strings.Contains(lc, "--port") {
 		transport = "sse/http"
 	}
@@ -523,6 +527,7 @@ func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body stri
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	//nolint:gosec // url is built from the connector's configured CrowdStrike region host, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -1,0 +1,672 @@
+package connector
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
+	"github.com/conductorone/baton-sdk/pkg/types/grant"
+	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	fClient "github.com/crowdstrike/gofalcon/falcon/client"
+	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// mcpRunnerEntitlement is the assignment entitlement on an mcp_server resource held
+// by the endpoint user that ran the server.
+const mcpRunnerEntitlement = "runner"
+
+// mcpServerAlertLimit is how many recent alerts we pull to scan for shadow-MCP activity.
+const mcpServerAlertLimit = 1000
+
+// mcpSignature matches the command line of a Model Context Protocol server. MCP
+// servers are ordinary npx/uvx/node/python processes whose command line carries a
+// recognizable package: @modelcontextprotocol/server-*, mcp-server-*, mcp_server_*.
+var mcpSignature = regexp.MustCompile(`(?i)(@modelcontextprotocol/server-[\w.-]+|mcp-server-[\w.-]+|mcp_server_[\w.-]+)`)
+
+// mcpServerResourceType syncs unsanctioned ("shadow") MCP servers observed on
+// endpoints via CrowdStrike EDR detections, correlates each to the identity that
+// ran it, and emits a queryable resource plus an identity-risk insight.
+type mcpServerResourceType struct {
+	resourceType *v2.ResourceType
+	client       *fClient.CrowdStrikeAPISpecification
+	src          *mcpSource
+}
+
+func (m *mcpServerResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return m.resourceType
+}
+
+// mcpDetection is a single shadow-MCP process-creation detection from the Alerts API.
+type mcpDetection struct {
+	Hostname    string
+	AID         string
+	LocalIP     string
+	UserName    string
+	CommandLine string
+	FilePath    string
+	Timestamp   time.Time
+	CompositeID string
+	FalconLink  string
+	IOARuleName string
+}
+
+// mcpServerInstance is a deduplicated (host, user, server) shadow-MCP server. The
+// same logical server surfaces under several command-line spellings across the
+// process tree; we collapse them and keep the most informative representation.
+type mcpServerInstance struct {
+	det         mcpDetection
+	serverName  string
+	pkg         string
+	launcher    string
+	transport   string
+	bestCmdline string // shortest signature-bearing command line (cleanest sample)
+	count       int
+}
+
+// resolvedIdentity carries the identity a detection's OS user maps to.
+type resolvedIdentity struct {
+	email       string
+	externalID  string
+	displayName string
+}
+
+// List scans recent EDR detections for shadow-MCP activity, correlates each to an
+// identity, and returns one mcp_server resource per unique server instance.
+func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	dets, err := m.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+
+	// Build an identity lookup keyed by lowercased samAccountName and email local-part.
+	idIndex, err := m.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to build identity index: %w", err)
+	}
+
+	instances := buildInstances(dets)
+
+	resources := make([]*v2.Resource, 0, len(instances))
+	for _, inst := range instances {
+		id := resolveIdentity(idIndex, inst.det.UserName)
+		res, err := mcpServerResource(inst, id)
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build mcp_server resource: %w", err)
+		}
+		resources = append(resources, res)
+	}
+
+	return resources, &rs.SyncOpResults{}, nil
+}
+
+// Entitlements exposes a single "runner" assignment on each mcp_server resource,
+// grantable to the endpoint user that ran the server.
+func (m *mcpServerResourceType) Entitlements(_ context.Context, resource *v2.Resource, _ rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	opts := []ent.EntitlementOption{
+		ent.WithGrantableTo(resourceTypeEndpointUser),
+		ent.WithDisplayName(fmt.Sprintf("%s runner", resource.DisplayName)),
+		ent.WithDescription("Endpoint user that ran this shadow MCP server"),
+	}
+	return []*v2.Entitlement{ent.NewAssignmentEntitlement(resource, mcpRunnerEntitlement, opts...)}, nil, nil
+}
+
+// Grants gives the endpoint-user account the "runner" entitlement on the mcp_server
+// resource it ran. The account is synced separately (see endpoint_user) and is
+// auto-matched to a c1 identity by email or assigned manually; this grant is what
+// surfaces it as the resource's principal.
+func (m *mcpServerResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	dets, err := m.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server grants: failed to fetch detections: %w", err)
+	}
+	for _, inst := range buildInstances(dets) {
+		if inst.objectID() != resource.Id.Resource {
+			continue
+		}
+		principal := &v2.ResourceId{ResourceType: resourceTypeEndpointUser.Id, Resource: inst.accountID()}
+		return []*v2.Grant{grant.NewGrant(resource, mcpRunnerEntitlement, principal)}, nil, nil
+	}
+	return nil, nil, nil
+}
+
+// mcpServerResource builds an mcp_server resource: an App-trait profile carrying the
+// full server + endpoint + identity metadata, plus a security-insight annotation
+// that binds a shadow-MCP finding to the resolved identity (when one is found).
+func mcpServerResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+
+	displayName := fmt.Sprintf("Shadow MCP: %s @ %s", inst.serverName, d.Hostname)
+	if d.UserName != "" {
+		displayName = fmt.Sprintf("%s (%s)", displayName, d.UserName)
+	}
+
+	profile := map[string]interface{}{
+		"server_name":         inst.serverName,
+		"package":             inst.pkg,
+		"launcher":            inst.launcher,
+		"transport":           inst.transport,
+		"sanctioned":          false,
+		"endpoint_user":       d.UserName,
+		"host":                d.Hostname,
+		"aid":                 d.AID,
+		"local_ip":            d.LocalIP,
+		"sample_command_line": inst.bestCmdline,
+		"detection_count":     inst.count,
+		"ioa_rule":            d.IOARuleName,
+		"falcon_link":         d.FalconLink,
+	}
+	if !d.Timestamp.IsZero() {
+		profile["first_seen"] = d.Timestamp.UTC().Format(time.RFC3339)
+	}
+	if id != nil {
+		profile["identity_email"] = id.email
+		profile["identity_external_id"] = id.externalID
+		profile["identity_display_name"] = id.displayName
+	}
+
+	opts := []rs.ResourceOption{
+		rs.WithAppTrait(rs.WithAppProfile(profile)),
+	}
+
+	// Bind the finding to the identity as a security insight (issue) so it flows into
+	// c1 identity risk. Requires a resolved identity with an external ID.
+	if id != nil && id.externalID != "" {
+		issueVal := fmt.Sprintf("Shadow MCP server '%s' (%s via %s/%s) running on %s as %s",
+			inst.serverName, inst.pkg, inst.launcher, inst.transport, d.Hostname, d.UserName)
+		insightOpts := []rs.SecurityInsightTraitOption{
+			rs.WithIssue(issueVal),
+			rs.WithIssueSeverity("High"),
+			rs.WithInsightAppUserTarget(id.email, id.externalID),
+		}
+		if !d.Timestamp.IsZero() {
+			insightOpts = append(insightOpts, rs.WithInsightObservedAt(d.Timestamp))
+		}
+		insight, err := rs.NewSecurityInsightTrait(insightOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build security insight trait: %w", err)
+		}
+		opts = append(opts, rs.WithAnnotation(insight))
+	}
+
+	return rs.NewResource(displayName, resourceTypeMCPServer, inst.objectID(), opts...)
+}
+
+// buildInstances deduplicates detections into unique server instances, keyed by the
+// logical server (host, user, server name) so the different command-line spellings of
+// the same server (e.g. "node ... @modelcontextprotocol/server-everything" and
+// "sh -c mcp-server-everything") collapse into one resource.
+func buildInstances(dets []mcpDetection) map[string]*mcpServerInstance {
+	instances := map[string]*mcpServerInstance{}
+	for _, d := range dets {
+		if d.AID == "" || d.UserName == "" {
+			continue // unattributable — avoid collapsing distinct hosts/users into one id
+		}
+		name, pkg, launcher, transport, ok := parseMCPServer(d.CommandLine)
+		if !ok {
+			continue
+		}
+		key := strings.Join([]string{d.AID, strings.ToLower(d.UserName), name}, "|")
+		inst, seen := instances[key]
+		if !seen {
+			instances[key] = &mcpServerInstance{
+				det: d, serverName: name, pkg: pkg, launcher: launcher, transport: transport,
+				bestCmdline: d.CommandLine, count: 1,
+			}
+			continue
+		}
+		inst.count++
+		if !d.Timestamp.IsZero() && (inst.det.Timestamp.IsZero() || d.Timestamp.Before(inst.det.Timestamp)) {
+			inst.det.Timestamp = d.Timestamp
+		}
+		if inst.launcher == "unknown" && launcher != "unknown" {
+			inst.launcher = launcher
+			inst.transport = transport
+		}
+		if strings.HasPrefix(pkg, "@modelcontextprotocol/") {
+			inst.pkg = pkg
+		}
+		if len(d.CommandLine) < len(inst.bestCmdline) {
+			inst.bestCmdline = d.CommandLine
+		}
+	}
+	return instances
+}
+
+// objectID is the stable mcp_server resource ID. It hashes aid|user|serverName — the
+// same fields buildInstances dedups on — so the ID is stable across syncs regardless of
+// which command-line spelling (mcp-server-x vs @modelcontextprotocol/server-x) happens
+// to appear in a given alert window, and always agrees with the dedup key.
+func (inst *mcpServerInstance) objectID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName), inst.serverName}, "|")))
+	return "mcp-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// accountID is the stable endpoint_user account ID (sha256 of aid|user), shared by
+// every server the same user ran on the same host.
+func (inst *mcpServerInstance) accountID() string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{inst.det.AID, strings.ToLower(inst.det.UserName)}, "|")))
+	return "eu-" + hex.EncodeToString(sum[:])[:24]
+}
+
+// endpointUserResourceType syncs the endpoint OS users that ran shadow MCP servers as
+// app accounts, so they can be assigned to a ConductorOne identity and shown against
+// the mcp_server resources they ran.
+type endpointUserResourceType struct {
+	resourceType *v2.ResourceType
+	src          *mcpSource
+}
+
+func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
+	return e.resourceType
+}
+
+func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	dets, err := e.src.detections(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
+	}
+	if len(dets) == 0 {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+	idIndex, err := e.src.identityIndex(ctx, opts.SyncID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to build identity index: %w", err)
+	}
+
+	seen := map[string]bool{}
+	var rv []*v2.Resource
+	for _, inst := range buildInstances(dets) {
+		acctID := inst.accountID()
+		if seen[acctID] {
+			continue
+		}
+		seen[acctID] = true
+		res, err := endpointUserResource(inst, resolveIdentity(idIndex, inst.det.UserName))
+		if err != nil {
+			return nil, nil, fmt.Errorf("baton-crowdstrike: failed to build endpoint_user resource: %w", err)
+		}
+		rv = append(rv, res)
+	}
+	return rv, &rs.SyncOpResults{}, nil
+}
+
+func (e *endpointUserResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+func (e *endpointUserResourceType) Grants(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
+	return nil, nil, nil
+}
+
+// endpointUserResource builds a user-trait account for an endpoint OS user. When the
+// user resolves to an Identity Protection entity, its email is attached so c1 can
+// auto-match; otherwise the account stays unmatched for manual assignment.
+func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Resource, error) {
+	d := inst.det
+	profile := map[string]interface{}{
+		"endpoint_user": d.UserName,
+		"host":          d.Hostname,
+		"aid":           d.AID,
+		"local_ip":      d.LocalIP,
+	}
+	displayName := fmt.Sprintf("%s@%s", d.UserName, d.Hostname)
+	traitOpts := []rs.UserTraitOption{rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED)}
+	if id != nil {
+		if id.displayName != "" {
+			displayName = fmt.Sprintf("%s (%s@%s)", id.displayName, d.UserName, d.Hostname)
+		}
+		profile["resolved_identity"] = id.displayName
+		profile["identity_external_id"] = id.externalID
+		if id.email != "" {
+			traitOpts = append(traitOpts, rs.WithEmail(id.email, true))
+		}
+	}
+	traitOpts = append(traitOpts, rs.WithUserProfile(profile))
+	return rs.NewUserResource(displayName, resourceTypeEndpointUser, inst.accountID(), traitOpts)
+}
+
+// buildIdentityIndex fetches all Identity Protection entities and indexes them by
+// lowercased samAccountName and email local-part for endpoint-user resolution.
+//
+// Endpoint usernames are ambiguous: two distinct identities can share a samAccountName
+// or email local-part. Rather than silently letting the last one win (which would pin a
+// shadow-MCP finding on the wrong person), a key that maps to more than one identity is
+// marked ambiguous (nil) and resolves to no match.
+func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, error) {
+	index := map[string]*resolvedIdentity{}
+	// insert records key->ri, but collapses to nil (ambiguous) if the key already
+	// resolves to a different identity.
+	insert := func(key string, ri *resolvedIdentity) {
+		key = strings.ToLower(key)
+		if key == "" {
+			return
+		}
+		existing, seen := index[key]
+		if !seen {
+			index[key] = ri
+			return
+		}
+		if existing == nil {
+			return // already ambiguous
+		}
+		if existing.externalID != ri.externalID {
+			index[key] = nil // collision between distinct identities
+		}
+	}
+	cursor := ""
+	for {
+		identities, next, hasNext, _, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
+		if err != nil {
+			return nil, err
+		}
+		for i := range identities {
+			id := identities[i]
+			email := ""
+			if len(id.EmailAddresses) > 0 {
+				email = id.EmailAddresses[0]
+			} else if validateEmail(id.SecondaryDisplayName) {
+				email = id.SecondaryDisplayName
+			}
+			for _, acct := range id.Accounts {
+				if acct.SamAccountName != "" {
+					insert(acct.SamAccountName, &resolvedIdentity{email: email, externalID: acct.ExternalID(), displayName: id.PrimaryDisplayName})
+				}
+			}
+			if email != "" {
+				if local := strings.SplitN(email, "@", 2)[0]; local != "" {
+					insert(local, &resolvedIdentity{email: email, externalID: firstExternalID(id), displayName: id.PrimaryDisplayName})
+				}
+			}
+		}
+		if !hasNext || next == "" {
+			break
+		}
+		cursor = next
+	}
+	return index, nil
+}
+
+func firstExternalID(id IdentityRiskData) string {
+	for _, acct := range id.Accounts {
+		if ext := acct.ExternalID(); ext != "" {
+			return ext
+		}
+	}
+	return ""
+}
+
+// resolveIdentity maps an endpoint OS username to an identity via samAccountName or email local-part.
+func resolveIdentity(index map[string]*resolvedIdentity, userName string) *resolvedIdentity {
+	if userName == "" {
+		return nil
+	}
+	if ri, ok := index[strings.ToLower(userName)]; ok {
+		return ri
+	}
+	return nil
+}
+
+// parseMCPServer extracts the MCP server identity from a process command line.
+func parseMCPServer(cmdline string) (name, pkg, launcher, transport string, ok bool) {
+	match := mcpSignature.FindString(cmdline)
+	if match == "" {
+		return "", "", "", "", false
+	}
+	// A bare .js entrypoint (e.g. mcp-server-fetch.js) and its package name are the same
+	// logical server; drop the extension so they don't split into two resources.
+	match = strings.TrimSuffix(match, ".js")
+	pkg = match
+	// Derive a short logical name from the package suffix.
+	switch {
+	case strings.HasPrefix(match, "@modelcontextprotocol/server-"):
+		name = strings.TrimPrefix(match, "@modelcontextprotocol/server-")
+	case strings.HasPrefix(match, "mcp-server-"):
+		name = strings.TrimPrefix(match, "mcp-server-")
+	case strings.HasPrefix(match, "mcp_server_"):
+		name = strings.TrimPrefix(match, "mcp_server_")
+	default:
+		name = match
+	}
+
+	lc := strings.ToLower(cmdline)
+	switch {
+	case strings.Contains(lc, "npx"):
+		launcher = "npx"
+	case strings.Contains(lc, "uvx"):
+		launcher = "uvx"
+	case strings.Contains(lc, "python"):
+		launcher = "python"
+	case strings.Contains(lc, "node"):
+		launcher = "node"
+	default:
+		launcher = "unknown"
+	}
+
+	transport = "stdio"
+	if strings.Contains(lc, "--sse") || strings.Contains(lc, "transport sse") || strings.Contains(lc, "--port") {
+		transport = "sse/http"
+	}
+	return name, pkg, launcher, transport, true
+}
+
+// ---- Alerts API client (shadow-MCP detections) ----
+
+// mcpAlertMaxPages bounds how many pages of epp alerts we scan on very large tenants.
+// Each page holds up to mcpServerAlertLimit alerts.
+const mcpAlertMaxPages = 20
+
+type mcpDetectionsClient struct {
+	httpClient *http.Client
+	host       string
+}
+
+func newMCPDetectionsClient(ctx context.Context, clientID, clientSecret, host string) *mcpDetectionsClient {
+	config := clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     "https://" + host + "/oauth2/token",
+	}
+	httpClient := config.Client(ctx)
+	httpClient.Timeout = 30 * time.Second
+	return &mcpDetectionsClient{httpClient: httpClient, host: host}
+}
+
+type alertsQueryResp struct {
+	Resources []string `json:"resources"`
+}
+
+type alertsEntitiesResp struct {
+	Resources []struct {
+		Product     string `json:"product"`
+		UserName    string `json:"user_name"`
+		Cmdline     string `json:"cmdline"`
+		Filepath    string `json:"filepath"`
+		Timestamp   string `json:"timestamp"`
+		CompositeID string `json:"composite_id"`
+		FalconHost  string `json:"falcon_host_link"`
+		PatternName string `json:"name"`
+		Device      struct {
+			Hostname string `json:"hostname"`
+			DeviceID string `json:"device_id"`
+			LocalIP  string `json:"local_ip"`
+		} `json:"device"`
+	} `json:"resources"`
+}
+
+func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body string) ([]byte, error) {
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "baton-crowdstrike")
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
+	}
+	return b, nil
+}
+
+// fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL
+// product filter, paginating to exhaustion (bounded by mcpAlertMaxPages), then keeps
+// the ones whose command line matches the MCP signature. Detections missing an AID or
+// user name are dropped — they cannot be attributed to a host or identity.
+func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, error) {
+	filter := url.QueryEscape("product:'epp'")
+	var ids []string
+	truncated := false
+	for page := 0; ; page++ {
+		if page >= mcpAlertMaxPages {
+			truncated = true
+			break
+		}
+		qURL := fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
+			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit)
+		b, err := c.doJSON(ctx, http.MethodGet, qURL, "")
+		if err != nil {
+			return nil, err
+		}
+		var q alertsQueryResp
+		if err := json.Unmarshal(b, &q); err != nil {
+			return nil, err
+		}
+		ids = append(ids, q.Resources...)
+		if len(q.Resources) < mcpServerAlertLimit {
+			break
+		}
+	}
+	if truncated {
+		ctxzap.Extract(ctx).Warn("baton-crowdstrike: mcp detection scan hit page cap; older epp alerts not scanned",
+			zap.Int("scanned_alerts", len(ids)), zap.Int("page_cap", mcpAlertMaxPages))
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	var out []mcpDetection
+	for start := 0; start < len(ids); start += mcpServerAlertLimit {
+		end := start + mcpServerAlertLimit
+		if end > len(ids) {
+			end = len(ids)
+		}
+		detBody, _ := json.Marshal(map[string]interface{}{"composite_ids": ids[start:end]})
+		b, err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host), string(detBody))
+		if err != nil {
+			return nil, err
+		}
+		var e alertsEntitiesResp
+		if err := json.Unmarshal(b, &e); err != nil {
+			return nil, err
+		}
+		for _, a := range e.Resources {
+			if a.Product != "epp" || !mcpSignature.MatchString(a.Cmdline) {
+				continue
+			}
+			if a.Device.DeviceID == "" || a.UserName == "" {
+				continue // unattributable to a host/identity
+			}
+			ts, _ := time.Parse(time.RFC3339, a.Timestamp)
+			out = append(out, mcpDetection{
+				Hostname: a.Device.Hostname, AID: a.Device.DeviceID, LocalIP: a.Device.LocalIP,
+				UserName: a.UserName, CommandLine: a.Cmdline, FilePath: a.Filepath, Timestamp: ts,
+				CompositeID: a.CompositeID, FalconLink: a.FalconHost, IOARuleName: a.PatternName,
+			})
+		}
+	}
+	return out, nil
+}
+
+// mcpSource is a per-connector data source shared by the mcp_server and endpoint_user
+// syncers. It memoizes the detection snapshot and identity index per sync (keyed by
+// SyncID) so every List/Grants call across both resource types sees one consistent
+// snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
+// that independent re-fetches would cause. Only the current sync's data is retained.
+type mcpSource struct {
+	detClient *mcpDetectionsClient
+	ipClient  *IdentityProtectionClient
+
+	mu      sync.Mutex
+	detSync string
+	detData []mcpDetection
+	idxSync string
+	idxData map[string]*resolvedIdentity
+}
+
+func newMCPSource(ctx context.Context, clientID, clientSecret, host string) *mcpSource {
+	return &mcpSource{
+		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
+		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+	}
+}
+
+func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
+	s.mu.Lock()
+	if s.detData != nil && s.detSync == syncID {
+		d := s.detData
+		s.mu.Unlock()
+		return d, nil
+	}
+	s.mu.Unlock()
+	d, err := s.detClient.fetchAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.detSync, s.detData = syncID, d
+	s.mu.Unlock()
+	return d, nil
+}
+
+func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
+	s.mu.Lock()
+	if s.idxData != nil && s.idxSync == syncID {
+		idx := s.idxData
+		s.mu.Unlock()
+		return idx, nil
+	}
+	s.mu.Unlock()
+	idx, err := buildIdentityIndex(ctx, s.ipClient)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	s.idxSync, s.idxData = syncID, idx
+	s.mu.Unlock()
+	return idx, nil
+}
+
+func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {
+	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src}
+}
+
+func endpointUserBuilder(src *mcpSource) *endpointUserResourceType {
+	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src}
+}

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -19,10 +16,10 @@ import (
 	ent "github.com/conductorone/baton-sdk/pkg/types/entitlement"
 	"github.com/conductorone/baton-sdk/pkg/types/grant"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
 	"github.com/grpc-ecosystem/go-grpc-middleware/logging/zap/ctxzap"
 	"go.uber.org/zap"
-	"golang.org/x/oauth2/clientcredentials"
 )
 
 // mcpRunnerEntitlement is the assignment entitlement on an mcp_server resource held
@@ -479,18 +476,11 @@ func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 const mcpAlertMaxPages = 10
 
 type mcpDetectionsClient struct {
-	httpClient *http.Client
+	httpClient *uhttp.BaseHttpClient
 	host       string
 }
 
-func newMCPDetectionsClient(ctx context.Context, clientID, clientSecret, host string) *mcpDetectionsClient {
-	config := clientcredentials.Config{
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		TokenURL:     "https://" + host + "/oauth2/token",
-	}
-	httpClient := config.Client(ctx)
-	httpClient.Timeout = 30 * time.Second
+func newMCPDetectionsClient(httpClient *uhttp.BaseHttpClient, host string) *mcpDetectionsClient {
 	return &mcpDetectionsClient{httpClient: httpClient, host: host}
 }
 
@@ -516,85 +506,6 @@ type alertsEntitiesResp struct {
 	} `json:"resources"`
 }
 
-// mcpMaxRetries is how many times doJSON retries a rate-limited (429) or transient
-// server (5xx) response before giving up.
-const mcpMaxRetries = 4
-
-func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, reqURL, body string) ([]byte, error) {
-	var lastErr error
-	for attempt := 0; attempt <= mcpMaxRetries; attempt++ {
-		var rdr io.Reader
-		if body != "" {
-			rdr = strings.NewReader(body)
-		}
-		req, err := http.NewRequestWithContext(ctx, method, reqURL, rdr)
-		if err != nil {
-			return nil, err
-		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", "baton-crowdstrike")
-		if body != "" {
-			req.Header.Set("Content-Type", "application/json")
-		}
-
-		resp, err := c.httpClient.Do(req)
-		if err != nil {
-			// Transient transport error — retry with backoff.
-			lastErr = err
-			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, 0) {
-				continue
-			}
-			return nil, err
-		}
-		b, _ := io.ReadAll(resp.Body)
-		_ = resp.Body.Close()
-
-		if resp.StatusCode == http.StatusOK {
-			return b, nil
-		}
-		// Retry on rate limiting and transient server errors, honoring Retry-After.
-		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
-			lastErr = fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
-			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, retryAfterSeconds(resp.Header)) {
-				continue
-			}
-			return nil, lastErr
-		}
-		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
-	}
-	return nil, lastErr
-}
-
-// retryAfterSeconds reads a Retry-After header expressed in seconds; 0 if absent/invalid.
-func retryAfterSeconds(h http.Header) int {
-	if v := h.Get("Retry-After"); v != "" {
-		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
-			return n
-		}
-	}
-	return 0
-}
-
-// waitBackoff sleeps before a retry — the larger of Retry-After and an exponential
-// backoff (1s, 2s, 4s, ... capped at 30s). Returns false if the context is cancelled.
-func waitBackoff(ctx context.Context, attempt, retryAfter int) bool {
-	backoff := time.Duration(1<<attempt) * time.Second
-	if backoff > 30*time.Second {
-		backoff = 30 * time.Second
-	}
-	if ra := time.Duration(retryAfter) * time.Second; ra > backoff {
-		backoff = ra
-	}
-	t := time.NewTimer(backoff)
-	defer t.Stop()
-	select {
-	case <-ctx.Done():
-		return false
-	case <-t.C:
-		return true
-	}
-}
-
 // fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL
 // product filter, paginating to exhaustion (bounded by mcpAlertMaxPages), then keeps
 // the ones whose command line matches the MCP signature. Detections missing an AID or
@@ -608,14 +519,21 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			truncated = true
 			break
 		}
-		qURL := fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
-			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit)
-		b, err := c.doJSON(ctx, http.MethodGet, qURL, "")
+		qURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
+			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit))
+		if err != nil {
+			return nil, err
+		}
+		req, err := c.httpClient.NewRequest(ctx, http.MethodGet, qURL, uhttp.WithAcceptJSONHeader())
 		if err != nil {
 			return nil, err
 		}
 		var q alertsQueryResp
-		if err := json.Unmarshal(b, &q); err != nil {
+		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&q))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err != nil {
 			return nil, err
 		}
 		ids = append(ids, q.Resources...)
@@ -631,19 +549,28 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 		return nil, nil
 	}
 
+	entitiesURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host))
+	if err != nil {
+		return nil, err
+	}
+
 	var out []mcpDetection
 	for start := 0; start < len(ids); start += mcpServerAlertLimit {
 		end := start + mcpServerAlertLimit
 		if end > len(ids) {
 			end = len(ids)
 		}
-		detBody, _ := json.Marshal(map[string]interface{}{"composite_ids": ids[start:end]})
-		b, err := c.doJSON(ctx, http.MethodPost, fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host), string(detBody))
+		req, err := c.httpClient.NewRequest(ctx, http.MethodPost, entitiesURL,
+			uhttp.WithJSONBody(map[string]interface{}{"composite_ids": ids[start:end]}), uhttp.WithAcceptJSONHeader())
 		if err != nil {
 			return nil, err
 		}
 		var e alertsEntitiesResp
-		if err := json.Unmarshal(b, &e); err != nil {
+		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&e))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		if err != nil {
 			return nil, err
 		}
 		for _, a := range e.Resources {
@@ -685,11 +612,11 @@ type mcpSource struct {
 	idxData map[string]*resolvedIdentity
 }
 
-func newMCPSource(ctx context.Context, clientID, clientSecret, host string, enabled bool) *mcpSource {
+func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *mcpSource {
 	return &mcpSource{
 		enabled:   enabled,
-		detClient: newMCPDetectionsClient(ctx, clientID, clientSecret, host),
-		ipClient:  NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		detClient: newMCPDetectionsClient(httpClient, host),
+		ipClient:  NewIdentityProtectionClient(httpClient, host),
 	}
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -527,7 +527,6 @@ func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body stri
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	//nolint:gosec // url is built from the connector's configured CrowdStrike region host, not user input
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -44,10 +44,6 @@ type mcpServerResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	src          *mcpSource
-	// enabled gates shadow-MCP detection specifically. The shared source may still run
-	// its scan for a sibling capability (AI-tool inventory), so this flag — not the
-	// source's — decides whether shadow-MCP resources are emitted.
-	enabled bool
 }
 
 func (m *mcpServerResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -91,9 +87,6 @@ type resolvedIdentity struct {
 // List scans recent EDR detections for shadow-MCP activity, correlates each to an
 // identity, and returns one mcp_server resource per unique server instance.
 func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	if !m.enabled {
-		return nil, &rs.SyncOpResults{}, nil
-	}
 	dets, err := m.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
@@ -278,9 +271,6 @@ func (inst *mcpServerInstance) accountID() string {
 type endpointUserResourceType struct {
 	resourceType *v2.ResourceType
 	src          *mcpSource
-	// enabled gates the endpoint-user accounts that back shadow-MCP resources; tied to
-	// the shadow-MCP capability, not the shared source (see mcpServerResourceType).
-	enabled bool
 }
 
 func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -288,9 +278,6 @@ func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceT
 }
 
 func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	if !e.enabled {
-		return nil, &rs.SyncOpResults{}, nil
-	}
 	dets, err := e.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
@@ -623,13 +610,6 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 // snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
 // that independent re-fetches would cause. Only the current sync's data is retained.
 type mcpSource struct {
-	// enabled gates the shared scan. It is the OR of the shadow-MCP and AI-tool
-	// capabilities: when both are off (the default) detections and the identity index
-	// are no-ops that make no CrowdStrike API calls. Which resources actually get
-	// emitted is decided per-syncer (see the enabled flag on each resource type), since
-	// one capability can be on while the other is off.
-	enabled bool
-
 	detClient *mcpDetectionsClient
 	ipClient  *IdentityProtectionClient
 
@@ -646,9 +626,8 @@ type mcpSource struct {
 	idxData    map[string]*resolvedIdentity
 }
 
-func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *mcpSource {
+func newMCPSource(httpClient *uhttp.BaseHttpClient, host string) *mcpSource {
 	return &mcpSource{
-		enabled:   enabled,
 		detClient: newMCPDetectionsClient(httpClient, host),
 		// Shadow-MCP identity resolution never needs password risk — keep it off.
 		ipClient: NewIdentityProtectionClient(httpClient, host, false),
@@ -656,9 +635,6 @@ func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *
 }
 
 func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
-	if !s.enabled {
-		return nil, nil
-	}
 	// Hold the lock across the fetch so the mcp_server and endpoint_user syncers —
 	// which run in parallel and share this source — perform exactly ONE Alerts scan
 	// per sync: the first caller fetches while the sibling blocks, then both see the
@@ -678,9 +654,6 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 }
 
 func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
-	if !s.enabled {
-		return map[string]*resolvedIdentity{}, nil
-	}
 	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -695,10 +668,10 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	return idx, nil
 }
 
-func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource, enabled bool) *mcpServerResourceType {
-	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src, enabled: enabled}
+func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {
+	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src}
 }
 
-func endpointUserBuilder(src *mcpSource, enabled bool) *endpointUserResourceType {
-	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src, enabled: enabled}
+func endpointUserBuilder(src *mcpSource) *endpointUserResourceType {
+	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src}
 }

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -87,18 +87,18 @@ type resolvedIdentity struct {
 // List scans recent EDR detections for shadow-MCP activity, correlates each to an
 // identity, and returns one mcp_server resource per unique server instance.
 func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	dets, err := m.src.detections(ctx, opts.SyncID)
+	dets, detRL, err := m.src.detections(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "mcp_server list: failed to fetch detections")
 	}
 	if len(dets) == 0 {
-		return nil, &rs.SyncOpResults{}, nil
+		return nil, &rs.SyncOpResults{Annotations: WithRateLimitAnnotations(detRL)}, nil
 	}
 
 	// Build an identity lookup keyed by lowercased samAccountName and email local-part.
-	idIndex, err := m.src.identityIndex(ctx, opts.SyncID)
+	idIndex, idxRL, err := m.src.identityIndex(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to build identity index: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "mcp_server list: failed to build identity index")
 	}
 
 	instances := buildInstances(dets)
@@ -113,7 +113,8 @@ func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts
 		resources = append(resources, res)
 	}
 
-	return resources, &rs.SyncOpResults{}, nil
+	annos := WithRateLimitAnnotations(detRL, idxRL)
+	return resources, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 // Entitlements exposes a single "runner" assignment on each mcp_server resource,
@@ -132,18 +133,19 @@ func (m *mcpServerResourceType) Entitlements(_ context.Context, resource *v2.Res
 // auto-matched to a c1 identity by email or assigned manually; this grant is what
 // surfaces it as the resource's principal.
 func (m *mcpServerResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
-	dets, err := m.src.detections(ctx, opts.SyncID)
+	dets, detRL, err := m.src.detections(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server grants: failed to fetch detections: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "mcp_server grants: failed to fetch detections")
 	}
+	annos := WithRateLimitAnnotations(detRL)
 	for _, inst := range buildInstances(dets) {
 		if inst.objectID() != resource.Id.Resource {
 			continue
 		}
 		principal := &v2.ResourceId{ResourceType: resourceTypeEndpointUser.Id, Resource: inst.accountID()}
-		return []*v2.Grant{grant.NewGrant(resource, mcpRunnerEntitlement, principal)}, nil, nil
+		return []*v2.Grant{grant.NewGrant(resource, mcpRunnerEntitlement, principal)}, &rs.SyncOpResults{Annotations: annos}, nil
 	}
-	return nil, nil, nil
+	return nil, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 // mcpServerResource builds an mcp_server resource: an App-trait profile carrying the
@@ -278,16 +280,16 @@ func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceT
 }
 
 func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	dets, err := e.src.detections(ctx, opts.SyncID)
+	dets, detRL, err := e.src.detections(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "endpoint_user list: failed to fetch detections")
 	}
 	if len(dets) == 0 {
-		return nil, &rs.SyncOpResults{}, nil
+		return nil, &rs.SyncOpResults{Annotations: WithRateLimitAnnotations(detRL)}, nil
 	}
-	idIndex, err := e.src.identityIndex(ctx, opts.SyncID)
+	idIndex, idxRL, err := e.src.identityIndex(ctx, opts.SyncID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to build identity index: %w", err)
+		return nil, nil, wrapCrowdStrikeError(err, "endpoint_user list: failed to build identity index")
 	}
 
 	seen := map[string]bool{}
@@ -304,7 +306,8 @@ func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, o
 		}
 		rv = append(rv, res)
 	}
-	return rv, &rs.SyncOpResults{}, nil
+	annos := WithRateLimitAnnotations(detRL, idxRL)
+	return rv, &rs.SyncOpResults{Annotations: annos}, nil
 }
 
 func (e *endpointUserResourceType) Entitlements(context.Context, *v2.Resource, rs.SyncOpAttrs) ([]*v2.Entitlement, *rs.SyncOpResults, error) {
@@ -354,8 +357,9 @@ func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Re
 // turn a single sync into an unbounded sequence of sequential GraphQL round trips.
 const mcpIdentityIndexMaxPages = 100
 
-func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, error) {
+func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, RateLimitInfo, error) {
 	index := map[string]*resolvedIdentity{}
+	var rl RateLimitInfo
 	// insert records key->ri, but collapses to nil (ambiguous) if the key already
 	// resolves to a different identity.
 	insert := func(key string, ri *resolvedIdentity) {
@@ -377,9 +381,10 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 	}
 	cursor := ""
 	for page := 0; page < mcpIdentityIndexMaxPages; page++ {
-		identities, next, hasNext, _, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
+		identities, next, hasNext, pageRL, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
+		rl = worseRateLimit(rl, pageRL)
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		for i := range identities {
 			id := identities[i]
@@ -401,7 +406,7 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 			}
 		}
 		if !hasNext || next == "" {
-			return index, nil
+			return index, rl, nil
 		}
 		cursor = next
 	}
@@ -409,7 +414,26 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 	// so some endpoint users may not resolve to an identity.
 	ctxzap.Extract(ctx).Warn("baton-crowdstrike: identity index hit page cap; not all identities indexed",
 		zap.Int("page_cap", mcpIdentityIndexMaxPages), zap.Int("indexed_keys", len(index)))
-	return index, nil
+	return index, rl, nil
+}
+
+// worseRateLimit prefers the response with the lower remaining budget when both
+// carry rate-limit headers (worst-case across multi-call paths). Empty infos are ignored.
+func worseRateLimit(a, b RateLimitInfo) RateLimitInfo {
+	aEmpty := a.Limit == 0 && a.Remaining == 0
+	bEmpty := b.Limit == 0 && b.Remaining == 0
+	switch {
+	case aEmpty && bEmpty:
+		return RateLimitInfo{}
+	case aEmpty:
+		return b
+	case bEmpty:
+		return a
+	case b.Remaining < a.Remaining:
+		return b
+	default:
+		return a
+	}
 }
 
 func firstExternalID(id IdentityRiskData) string {
@@ -519,9 +543,11 @@ type alertsEntitiesResp struct {
 // product filter, paginating to exhaustion (bounded by mcpAlertMaxPages), then keeps
 // the ones whose command line matches the MCP signature. Detections missing an AID or
 // user name are dropped — they cannot be attributed to a host or identity.
-func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, error) {
+// Rate-limit headers from Alerts responses are aggregated (worst remaining).
+func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, RateLimitInfo, error) {
 	filter := url.QueryEscape("product:'epp'")
 	var ids []string
+	var rl RateLimitInfo
 	truncated := false
 	for page := 0; ; page++ {
 		if page >= mcpAlertMaxPages {
@@ -531,19 +557,20 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 		qURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/queries/alerts/v2?filter=%s&limit=%d&offset=%d&sort=timestamp.desc",
 			c.host, filter, mcpServerAlertLimit, page*mcpServerAlertLimit))
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		req, err := c.httpClient.NewRequest(ctx, http.MethodGet, qURL, uhttp.WithAcceptJSONHeader())
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		var q alertsQueryResp
 		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&q))
 		if resp != nil {
+			rl = worseRateLimit(rl, extractRateLimitInfo(resp))
 			resp.Body.Close()
 		}
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		ids = append(ids, q.Resources...)
 		if len(q.Resources) < mcpServerAlertLimit {
@@ -555,12 +582,12 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			zap.Int("scanned_alerts", len(ids)), zap.Int("page_cap", mcpAlertMaxPages))
 	}
 	if len(ids) == 0 {
-		return nil, nil
+		return nil, rl, nil
 	}
 
 	entitiesURL, err := url.Parse(fmt.Sprintf("https://%s/alerts/entities/alerts/v2", c.host))
 	if err != nil {
-		return nil, err
+		return nil, rl, err
 	}
 
 	var out []mcpDetection
@@ -572,15 +599,16 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 		req, err := c.httpClient.NewRequest(ctx, http.MethodPost, entitiesURL,
 			uhttp.WithJSONBody(map[string]interface{}{"composite_ids": ids[start:end]}), uhttp.WithAcceptJSONHeader())
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		var e alertsEntitiesResp
 		resp, err := c.httpClient.Do(req, uhttp.WithJSONResponse(&e))
 		if resp != nil {
+			rl = worseRateLimit(rl, extractRateLimitInfo(resp))
 			resp.Body.Close()
 		}
 		if err != nil {
-			return nil, err
+			return nil, rl, err
 		}
 		for _, a := range e.Resources {
 			// Keep an alert if its command line looks like a shadow MCP server OR a
@@ -601,7 +629,7 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			})
 		}
 	}
-	return out, nil
+	return out, rl, nil
 }
 
 // mcpSource is a per-connector data source shared by the mcp_server, endpoint_user, and
@@ -621,9 +649,11 @@ type mcpSource struct {
 	detFetched bool
 	detSync    string
 	detData    []mcpDetection
+	detRL      RateLimitInfo
 	idxFetched bool
 	idxSync    string
 	idxData    map[string]*resolvedIdentity
+	idxRL      RateLimitInfo
 }
 
 func newMCPSource(httpClient *uhttp.BaseHttpClient, host string) *mcpSource {
@@ -634,7 +664,7 @@ func newMCPSource(httpClient *uhttp.BaseHttpClient, host string) *mcpSource {
 	}
 }
 
-func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, error) {
+func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetection, RateLimitInfo, error) {
 	// Hold the lock across the fetch so the mcp_server and endpoint_user syncers —
 	// which run in parallel and share this source — perform exactly ONE Alerts scan
 	// per sync: the first caller fetches while the sibling blocks, then both see the
@@ -643,29 +673,29 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.detFetched && s.detSync == syncID {
-		return s.detData, nil
+		return s.detData, s.detRL, nil
 	}
-	d, err := s.detClient.fetchAll(ctx)
+	d, rl, err := s.detClient.fetchAll(ctx)
 	if err != nil {
-		return nil, err
+		return nil, rl, err
 	}
-	s.detFetched, s.detSync, s.detData = true, syncID, d
-	return d, nil
+	s.detFetched, s.detSync, s.detData, s.detRL = true, syncID, d, rl
+	return d, rl, nil
 }
 
-func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, error) {
+func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[string]*resolvedIdentity, RateLimitInfo, error) {
 	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.idxFetched && s.idxSync == syncID {
-		return s.idxData, nil
+		return s.idxData, s.idxRL, nil
 	}
-	idx, err := buildIdentityIndex(ctx, s.ipClient)
+	idx, rl, err := buildIdentityIndex(ctx, s.ipClient)
 	if err != nil {
-		return nil, err
+		return nil, rl, err
 	}
-	s.idxFetched, s.idxSync, s.idxData = true, syncID, idx
-	return idx, nil
+	s.idxFetched, s.idxSync, s.idxData, s.idxRL = true, syncID, idx, rl
+	return idx, rl, nil
 }
 
 func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -472,8 +473,10 @@ func parseMCPServer(cmdline string) (string, string, string, string, bool) {
 // ---- Alerts API client (shadow-MCP detections) ----
 
 // mcpAlertMaxPages bounds how many pages of epp alerts we scan on very large tenants.
-// Each page holds up to mcpServerAlertLimit alerts.
-const mcpAlertMaxPages = 20
+// Each page holds up to mcpServerAlertLimit alerts. Capped at 10 so the largest offset
+// stays below CrowdStrike's ~10,000-record deep-pagination limit on the alerts query
+// endpoint (a request at offset >= 10000 is rejected).
+const mcpAlertMaxPages = 10
 
 type mcpDetectionsClient struct {
 	httpClient *http.Client
@@ -513,30 +516,83 @@ type alertsEntitiesResp struct {
 	} `json:"resources"`
 }
 
-func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, url, body string) ([]byte, error) {
-	var rdr io.Reader
-	if body != "" {
-		rdr = strings.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", "baton-crowdstrike")
-	if body != "" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	b, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK {
+// mcpMaxRetries is how many times doJSON retries a rate-limited (429) or transient
+// server (5xx) response before giving up.
+const mcpMaxRetries = 4
+
+func (c *mcpDetectionsClient) doJSON(ctx context.Context, method, reqURL, body string) ([]byte, error) {
+	var lastErr error
+	for attempt := 0; attempt <= mcpMaxRetries; attempt++ {
+		var rdr io.Reader
+		if body != "" {
+			rdr = strings.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, rdr)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", "baton-crowdstrike")
+		if body != "" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			// Transient transport error — retry with backoff.
+			lastErr = err
+			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, 0) {
+				continue
+			}
+			return nil, err
+		}
+		b, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			return b, nil
+		}
+		// Retry on rate limiting and transient server errors, honoring Retry-After.
+		if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError {
+			lastErr = fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
+			if attempt < mcpMaxRetries && waitBackoff(ctx, attempt, retryAfterSeconds(resp.Header)) {
+				continue
+			}
+			return nil, lastErr
+		}
 		return nil, fmt.Errorf("%s alerts returned %d: %s", method, resp.StatusCode, string(b))
 	}
-	return b, nil
+	return nil, lastErr
+}
+
+// retryAfterSeconds reads a Retry-After header expressed in seconds; 0 if absent/invalid.
+func retryAfterSeconds(h http.Header) int {
+	if v := h.Get("Retry-After"); v != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// waitBackoff sleeps before a retry — the larger of Retry-After and an exponential
+// backoff (1s, 2s, 4s, ... capped at 30s). Returns false if the context is cancelled.
+func waitBackoff(ctx context.Context, attempt, retryAfter int) bool {
+	backoff := time.Duration(1<<attempt) * time.Second
+	if backoff > 30*time.Second {
+		backoff = 30 * time.Second
+	}
+	if ra := time.Duration(retryAfter) * time.Second; ra > backoff {
+		backoff = ra
+	}
+	t := time.NewTimer(backoff)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }
 
 // fetchAll pulls endpoint-protection (epp) alerts, narrowed server-side by an FQL

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -184,7 +184,8 @@ func mcpServerResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Resou
 	}
 
 	opts := []rs.ResourceOption{
-		rs.WithAppTrait(rs.WithAppProfile(profile)),
+		rs.WithAppTrait(),
+		rs.WithResourceProfile(profile),
 	}
 
 	// Bind the finding to the identity as a security insight (issue) so it flows into
@@ -330,7 +331,11 @@ func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Re
 		"local_ip":      d.LocalIP,
 	}
 	displayName := fmt.Sprintf("%s@%s", d.UserName, d.Hostname)
-	traitOpts := []rs.UserTraitOption{rs.WithStatus(v2.UserTrait_Status_STATUS_ENABLED)}
+	var traitOpts []rs.UserTraitOption
+	resourceOpts := []rs.ResourceOption{
+		rs.WithResourceStatus(v2.Status_RESOURCE_STATUS_ENABLED, ""),
+		rs.WithResourceProfile(profile),
+	}
 	if id != nil {
 		if id.displayName != "" {
 			displayName = fmt.Sprintf("%s (%s@%s)", id.displayName, d.UserName, d.Hostname)
@@ -341,8 +346,7 @@ func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Re
 			traitOpts = append(traitOpts, rs.WithEmail(id.email, true))
 		}
 	}
-	traitOpts = append(traitOpts, rs.WithUserProfile(profile))
-	return rs.NewUserResource(displayName, resourceTypeEndpointUser, inst.accountID(), traitOpts)
+	return rs.NewUserResource(displayName, resourceTypeEndpointUser, inst.accountID(), traitOpts, resourceOpts...)
 }
 
 // buildIdentityIndex fetches all Identity Protection entities and indexes them by

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -614,11 +614,17 @@ type mcpSource struct {
 	detClient *mcpDetectionsClient
 	ipClient  *IdentityProtectionClient
 
-	mu      sync.Mutex
-	detSync string
-	detData []mcpDetection
-	idxSync string
-	idxData map[string]*resolvedIdentity
+	mu sync.Mutex
+	// detFetched/idxFetched track whether the current sync's fetch has run, so an
+	// empty result still caches (a nil/empty slice or map is a valid cached value —
+	// gating on the data being non-nil would re-scan every caller when a sync finds
+	// nothing). detSync/idxSync scope the cache to a single sync.
+	detFetched bool
+	detSync    string
+	detData    []mcpDetection
+	idxFetched bool
+	idxSync    string
+	idxData    map[string]*resolvedIdentity
 }
 
 func newMCPSource(httpClient *uhttp.BaseHttpClient, host string, enabled bool) *mcpSource {
@@ -640,14 +646,14 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 	// sequentially, never nested, so there is no lock-ordering hazard.)
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.detData != nil && s.detSync == syncID {
+	if s.detFetched && s.detSync == syncID {
 		return s.detData, nil
 	}
 	d, err := s.detClient.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	s.detSync, s.detData = syncID, d
+	s.detFetched, s.detSync, s.detData = true, syncID, d
 	return d, nil
 }
 
@@ -658,14 +664,14 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.idxData != nil && s.idxSync == syncID {
+	if s.idxFetched && s.idxSync == syncID {
 		return s.idxData, nil
 	}
 	idx, err := buildIdentityIndex(ctx, s.ipClient)
 	if err != nil {
 		return nil, err
 	}
-	s.idxSync, s.idxData = syncID, idx
+	s.idxFetched, s.idxSync, s.idxData = true, syncID, idx
 	return idx, nil
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -349,6 +349,11 @@ func endpointUserResource(inst *mcpServerInstance, id *resolvedIdentity) (*v2.Re
 // or email local-part. Rather than silently letting the last one win (which would pin a
 // shadow-MCP finding on the wrong person), a key that maps to more than one identity is
 // marked ambiguous (nil) and resolves to no match.
+// mcpIdentityIndexMaxPages bounds the Identity Protection entity pages scanned when
+// building the endpoint-user→identity resolution index, so a very large tenant can't
+// turn a single sync into an unbounded sequence of sequential GraphQL round trips.
+const mcpIdentityIndexMaxPages = 100
+
 func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[string]*resolvedIdentity, error) {
 	index := map[string]*resolvedIdentity{}
 	// insert records key->ri, but collapses to nil (ambiguous) if the key already
@@ -371,7 +376,7 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 		}
 	}
 	cursor := ""
-	for {
+	for page := 0; page < mcpIdentityIndexMaxPages; page++ {
 		identities, next, hasNext, _, err := ip.GetIdentityRiskScores(ctx, securityInsightPageSize, cursor)
 		if err != nil {
 			return nil, err
@@ -396,10 +401,14 @@ func buildIdentityIndex(ctx context.Context, ip *IdentityProtectionClient) (map[
 			}
 		}
 		if !hasNext || next == "" {
-			break
+			return index, nil
 		}
 		cursor = next
 	}
+	// Page cap reached with more identities remaining: the index is partial this sync,
+	// so some endpoint users may not resolve to an identity.
+	ctxzap.Extract(ctx).Warn("baton-crowdstrike: identity index hit page cap; not all identities indexed",
+		zap.Int("page_cap", mcpIdentityIndexMaxPages), zap.Int("indexed_keys", len(index)))
 	return index, nil
 }
 
@@ -624,20 +633,21 @@ func (s *mcpSource) detections(ctx context.Context, syncID string) ([]mcpDetecti
 	if !s.enabled {
 		return nil, nil
 	}
+	// Hold the lock across the fetch so the mcp_server and endpoint_user syncers —
+	// which run in parallel and share this source — perform exactly ONE Alerts scan
+	// per sync: the first caller fetches while the sibling blocks, then both see the
+	// same cached snapshot. (The two syncers call detections/identityIndex
+	// sequentially, never nested, so there is no lock-ordering hazard.)
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.detData != nil && s.detSync == syncID {
-		d := s.detData
-		s.mu.Unlock()
-		return d, nil
+		return s.detData, nil
 	}
-	s.mu.Unlock()
 	d, err := s.detClient.fetchAll(ctx)
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
 	s.detSync, s.detData = syncID, d
-	s.mu.Unlock()
 	return d, nil
 }
 
@@ -645,20 +655,17 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	if !s.enabled {
 		return map[string]*resolvedIdentity{}, nil
 	}
+	// Lock held across the build for the same one-build-per-sync reason as detections.
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	if s.idxData != nil && s.idxSync == syncID {
-		idx := s.idxData
-		s.mu.Unlock()
-		return idx, nil
+		return s.idxData, nil
 	}
-	s.mu.Unlock()
 	idx, err := buildIdentityIndex(ctx, s.ipClient)
 	if err != nil {
 		return nil, err
 	}
-	s.mu.Lock()
 	s.idxSync, s.idxData = syncID, idx
-	s.mu.Unlock()
 	return idx, nil
 }
 

--- a/pkg/connector/mcp_server.go
+++ b/pkg/connector/mcp_server.go
@@ -44,6 +44,10 @@ type mcpServerResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	src          *mcpSource
+	// enabled gates shadow-MCP detection specifically. The shared source may still run
+	// its scan for a sibling capability (AI-tool inventory), so this flag — not the
+	// source's — decides whether shadow-MCP resources are emitted.
+	enabled bool
 }
 
 func (m *mcpServerResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -87,6 +91,9 @@ type resolvedIdentity struct {
 // List scans recent EDR detections for shadow-MCP activity, correlates each to an
 // identity, and returns one mcp_server resource per unique server instance.
 func (m *mcpServerResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !m.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
 	dets, err := m.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: mcp_server list: failed to fetch detections: %w", err)
@@ -271,6 +278,9 @@ func (inst *mcpServerInstance) accountID() string {
 type endpointUserResourceType struct {
 	resourceType *v2.ResourceType
 	src          *mcpSource
+	// enabled gates the endpoint-user accounts that back shadow-MCP resources; tied to
+	// the shadow-MCP capability, not the shared source (see mcpServerResourceType).
+	enabled bool
 }
 
 func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -278,6 +288,9 @@ func (e *endpointUserResourceType) ResourceType(_ context.Context) *v2.ResourceT
 }
 
 func (e *endpointUserResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	if !e.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
 	dets, err := e.src.detections(ctx, opts.SyncID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("baton-crowdstrike: endpoint_user list: failed to fetch detections: %w", err)
@@ -583,7 +596,11 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 			return nil, err
 		}
 		for _, a := range e.Resources {
-			if a.Product != "epp" || !mcpSignature.MatchString(a.Cmdline) {
+			// Keep an alert if its command line looks like a shadow MCP server OR a
+			// known AI coding tool/harness — both capabilities read this one shared
+			// scan and each re-classifies the snapshot downstream.
+			aiRelated := mcpSignature.MatchString(a.Cmdline) || matchesHarness(a.Cmdline)
+			if a.Product != "epp" || !aiRelated {
 				continue
 			}
 			if a.Device.DeviceID == "" || a.UserName == "" {
@@ -600,15 +617,17 @@ func (c *mcpDetectionsClient) fetchAll(ctx context.Context) ([]mcpDetection, err
 	return out, nil
 }
 
-// mcpSource is a per-connector data source shared by the mcp_server and endpoint_user
-// syncers. It memoizes the detection snapshot and identity index per sync (keyed by
-// SyncID) so every List/Grants call across both resource types sees one consistent
+// mcpSource is a per-connector data source shared by the mcp_server, endpoint_user, and
+// ai_tool syncers. It memoizes the detection snapshot and identity index per sync (keyed
+// by SyncID) so every List/Grants call across those resource types sees one consistent
 // snapshot — avoiding redundant Alerts / Identity-Protection calls and the grant drift
 // that independent re-fetches would cause. Only the current sync's data is retained.
 type mcpSource struct {
-	// enabled gates shadow-MCP detection. When false (the default), detections and
-	// the identity index are no-ops that make no CrowdStrike API calls, so the
-	// mcp_server / endpoint_user syncers produce nothing — the capability is opt-in.
+	// enabled gates the shared scan. It is the OR of the shadow-MCP and AI-tool
+	// capabilities: when both are off (the default) detections and the identity index
+	// are no-ops that make no CrowdStrike API calls. Which resources actually get
+	// emitted is decided per-syncer (see the enabled flag on each resource type), since
+	// one capability can be on while the other is off.
 	enabled bool
 
 	detClient *mcpDetectionsClient
@@ -676,10 +695,10 @@ func (s *mcpSource) identityIndex(ctx context.Context, syncID string) (map[strin
 	return idx, nil
 }
 
-func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource) *mcpServerResourceType {
-	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src}
+func mcpServerBuilder(client *fClient.CrowdStrikeAPISpecification, src *mcpSource, enabled bool) *mcpServerResourceType {
+	return &mcpServerResourceType{resourceType: resourceTypeMCPServer, client: client, src: src, enabled: enabled}
 }
 
-func endpointUserBuilder(src *mcpSource) *endpointUserResourceType {
-	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src}
+func endpointUserBuilder(src *mcpSource, enabled bool) *endpointUserResourceType {
+	return &endpointUserResourceType{resourceType: resourceTypeEndpointUser, src: src, enabled: enabled}
 }

--- a/pkg/connector/mcp_server_test.go
+++ b/pkg/connector/mcp_server_test.go
@@ -1,0 +1,129 @@
+package connector
+
+import "testing"
+
+func TestParseMCPServer(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmdline    string
+		wantName   string
+		wantPkg    string
+		wantLaunch string
+		wantOK     bool
+	}{
+		{
+			name:       "npx scoped server",
+			cmdline:    "npx -y @modelcontextprotocol/server-filesystem /tmp",
+			wantName:   "filesystem",
+			wantPkg:    "@modelcontextprotocol/server-filesystem",
+			wantLaunch: "npx",
+			wantOK:     true,
+		},
+		{
+			// An npx-cached path contains "_npx", so npx provenance is reported.
+			name:       "node bin from npx cache resolves as npx",
+			cmdline:    "node /home/u/.npm/_npx/abc/node_modules/.bin/mcp-server-everything",
+			wantName:   "everything",
+			wantPkg:    "mcp-server-everything",
+			wantLaunch: "npx",
+			wantOK:     true,
+		},
+		{
+			name:       "pure node invocation",
+			cmdline:    "node /opt/mcp/bin/mcp-server-fetch",
+			wantName:   "fetch",
+			wantPkg:    "mcp-server-fetch",
+			wantLaunch: "node",
+			wantOK:     true,
+		},
+		{
+			// A bare .js entrypoint normalizes to the same name/pkg as the package form.
+			name:       "js entrypoint normalizes",
+			cmdline:    "node /opt/mcp/dist/mcp-server-fetch.js",
+			wantName:   "fetch",
+			wantPkg:    "mcp-server-fetch",
+			wantLaunch: "node",
+			wantOK:     true,
+		},
+		{
+			name:       "uvx python server",
+			cmdline:    "uvx mcp-server-time",
+			wantName:   "time",
+			wantPkg:    "mcp-server-time",
+			wantLaunch: "uvx",
+			wantOK:     true,
+		},
+		{
+			name:       "python module underscore package",
+			cmdline:    "python -m mcp_server_git",
+			wantName:   "git",
+			wantPkg:    "mcp_server_git",
+			wantLaunch: "python",
+			wantOK:     true,
+		},
+		{
+			name:       "shell wrapper without launcher token still matches",
+			cmdline:    "sh -c mcp-server-everything",
+			wantName:   "everything",
+			wantPkg:    "mcp-server-everything",
+			wantLaunch: "unknown",
+			wantOK:     true,
+		},
+		{
+			name:    "non-mcp process",
+			cmdline: "/usr/bin/bash -c ls -la /tmp",
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, pkg, launcher, transport, ok := parseMCPServer(tt.cmdline)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if name != tt.wantName {
+				t.Errorf("name = %q, want %q", name, tt.wantName)
+			}
+			if pkg != tt.wantPkg {
+				t.Errorf("pkg = %q, want %q", pkg, tt.wantPkg)
+			}
+			if launcher != tt.wantLaunch {
+				t.Errorf("launcher = %q, want %q", launcher, tt.wantLaunch)
+			}
+			if transport != "stdio" {
+				t.Errorf("transport = %q, want stdio", transport)
+			}
+		})
+	}
+}
+
+func TestParseMCPServerSSETransport(t *testing.T) {
+	_, _, _, transport, ok := parseMCPServer("node server.js mcp-server-fetch --sse --port 8080")
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if transport != "sse/http" {
+		t.Errorf("transport = %q, want sse/http", transport)
+	}
+}
+
+func TestResolveIdentityAmbiguous(t *testing.T) {
+	index := map[string]*resolvedIdentity{
+		"ambig":  nil, // ambiguous: two identities shared this samAccountName
+		"asmith": {email: "asmith@example.com", externalID: "ext-1", displayName: "A. Smith"},
+	}
+	if got := resolveIdentity(index, "ambig"); got != nil {
+		t.Errorf("ambiguous key resolved to %v, want nil", got)
+	}
+	if got := resolveIdentity(index, "unknown"); got != nil {
+		t.Errorf("unknown key resolved to %v, want nil", got)
+	}
+	got := resolveIdentity(index, "ASmith") // case-insensitive
+	if got == nil || got.externalID != "ext-1" {
+		t.Errorf("expected A. Smith (ext-1), got %v", got)
+	}
+}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -93,4 +93,24 @@ var (
 			),
 		),
 	}
+	// resourceTypeAITool models an AI coding tool ("harness" — Claude Code, Cursor,
+	// codex, etc.) observed running on an endpoint via CrowdStrike EDR detections. It
+	// carries an App-trait inventory profile (tool, endpoint, and resolved-identity
+	// metadata) and a low-severity security-insight annotation associating the tool with
+	// the identity that ran it. This is governance visibility, not a threat finding.
+	resourceTypeAITool = &v2.ResourceType{
+		Id:          "ai_tool",
+		DisplayName: "AI Coding Tool",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_APP,
+			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+				"Identity Protection GraphQL: Write",
+			),
+		),
+	}
 )

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -69,6 +69,7 @@ var (
 			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
 		},
 		Annotations: annotations.New(
+			&v2.OptInRequired{},
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",
@@ -87,6 +88,7 @@ var (
 		},
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
+			&v2.OptInRequired{},
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",
@@ -107,6 +109,7 @@ var (
 		},
 		Annotations: annotations.New(
 			&v2.SkipEntitlementsAndGrants{},
+			&v2.OptInRequired{},
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -57,4 +57,40 @@ var (
 			),
 		),
 	}
+	// resourceTypeMCPServer models an unsanctioned ("shadow") Model Context Protocol
+	// server observed running on an endpoint via CrowdStrike EDR detections. It carries
+	// a full App-trait profile (server, endpoint, and resolved-identity metadata) and a
+	// security-insight annotation binding the finding to the identity's c1 risk.
+	resourceTypeMCPServer = &v2.ResourceType{
+		Id:          "mcp_server",
+		DisplayName: "Shadow MCP Server",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_APP,
+			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
+		},
+		Annotations: annotations.New(
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+				"Identity Protection GraphQL: Write",
+			),
+		),
+	}
+	// resourceTypeEndpointUser is the endpoint OS user that ran a shadow MCP server,
+	// modeled as an app account so it can be assigned to a ConductorOne identity and
+	// shown against the mcp_server resources it ran (grant principal only).
+	resourceTypeEndpointUser = &v2.ResourceType{
+		Id:          "endpoint_user",
+		DisplayName: "Endpoint User",
+		Traits: []v2.ResourceType_Trait{
+			v2.ResourceType_TRAIT_USER,
+		},
+		Annotations: annotations.New(
+			&v2.SkipEntitlementsAndGrants{},
+			capabilityPermissions(
+				"Alerts: Read",
+				"Identity Protection Entities: Read",
+			),
+		),
+	}
 )

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -92,6 +92,8 @@ var (
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",
+				// Identity index for endpoint-user→identity resolution uses GraphQL.
+				"Identity Protection GraphQL: Write",
 			),
 		),
 	}

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -106,6 +106,7 @@ var (
 			v2.ResourceType_TRAIT_SECURITY_INSIGHT,
 		},
 		Annotations: annotations.New(
+			&v2.SkipEntitlementsAndGrants{},
 			capabilityPermissions(
 				"Alerts: Read",
 				"Identity Protection Entities: Read",

--- a/pkg/connector/role.go
+++ b/pkg/connector/role.go
@@ -40,15 +40,12 @@ func roleResource(role *models.DomainRole) (*v2.Resource, error) {
 		"description": description,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
-
 	resource, err := rs.NewRoleResource(
 		displayName,
 		resourceTypeRole,
 		id,
-		roleTraitOptions,
+		nil,
+		rs.WithResourceProfile(profile),
 	)
 
 	if err != nil {

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -213,11 +213,11 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, enabled bool) *securityInsightResourceType {
+func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, enabled, includePasswordRisk bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
-		ipClient:     NewIdentityProtectionClient(httpClient, host),
+		ipClient:     NewIdentityProtectionClient(httpClient, host, includePasswordRisk),
 		enabled:      enabled,
 	}
 }

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -30,9 +30,6 @@ type securityInsightResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	ipClient     *IdentityProtectionClient
-	// enabled gates risk-score ingestion (on by default). When false, List is a
-	// no-op that makes no Identity Protection API call.
-	enabled bool
 }
 
 func (s *securityInsightResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -115,12 +112,6 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 }
 
 func (s *securityInsightResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	// When risk-score ingestion is disabled, sync nothing and make no Identity
-	// Protection API call.
-	if !s.enabled {
-		return nil, &rs.SyncOpResults{}, nil
-	}
-
 	// Parse the page token to get the cursor
 	cursor := opts.PageToken.Token
 
@@ -213,11 +204,10 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, enabled, includePasswordRisk bool) *securityInsightResourceType {
+func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, includePasswordRisk bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
 		ipClient:     NewIdentityProtectionClient(httpClient, host, includePasswordRisk),
-		enabled:      enabled,
 	}
 }

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -16,6 +16,14 @@ import (
 const (
 	// securityInsightPageSize is the number of identity risk scores to fetch per page.
 	securityInsightPageSize = 100
+
+	// Risk-factor type labels derived from Identity Protection password attributes.
+	// CrowdStrike does not model these as RiskFactorType enum values, so they are
+	// surfaced as descriptive risk factors on the account's security insight.
+	riskFactorExposedPassword = "EXPOSED_PASSWORD"
+	riskFactorWeakPassword    = "WEAK_PASSWORD"
+
+	passwordStrengthWeak = "WEAK"
 )
 
 type securityInsightResourceType struct {
@@ -77,12 +85,15 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 		rs.WithNormalizedRiskScore(normalizedScore, sourceScore),
 	}
 
-	// Add structured risk factors if present
-	if len(identity.RiskFactors) > 0 {
-		factors := make([]*v2.RiskFactor, 0, len(identity.RiskFactors))
-		for _, rf := range identity.RiskFactors {
-			factors = append(factors, rs.NewRiskFactor(rf.Type, mapRiskFactorSeverity(rf.Severity)))
-		}
+	// Add structured risk factors: the entity-level factors from Identity Protection,
+	// plus per-account password risk (compromised/weak) derived from the account's
+	// password attributes.
+	factors := make([]*v2.RiskFactor, 0, len(identity.RiskFactors)+2)
+	for _, rf := range identity.RiskFactors {
+		factors = append(factors, rs.NewRiskFactor(rf.Type, mapRiskFactorSeverity(rf.Severity)))
+	}
+	factors = append(factors, passwordRiskFactors(account)...)
+	if len(factors) > 0 {
 		traitOpts = append(traitOpts, rs.WithRiskFactors(factors...))
 	}
 
@@ -167,6 +178,24 @@ func (s *securityInsightResourceType) Entitlements(ctx context.Context, resource
 func (s *securityInsightResourceType) Grants(ctx context.Context, resource *v2.Resource, opts rs.SyncOpAttrs) ([]*v2.Grant, *rs.SyncOpResults, error) {
 	// Security insights do not have grants
 	return nil, nil, nil
+}
+
+// passwordRiskFactors derives risk factors from an account's password attributes:
+// an exposed (compromised/breached) password is a HIGH risk factor, a weak password
+// is MEDIUM. Returns nil when the account exposes no password attributes or no signal.
+func passwordRiskFactors(account AccountData) []*v2.RiskFactor {
+	pa := account.PasswordAttributes
+	if pa == nil {
+		return nil
+	}
+	var factors []*v2.RiskFactor
+	if pa.Exposed {
+		factors = append(factors, rs.NewRiskFactor(riskFactorExposedPassword, v2.RiskFactor_SEVERITY_HIGH))
+	}
+	if strings.EqualFold(pa.Strength, passwordStrengthWeak) {
+		factors = append(factors, rs.NewRiskFactor(riskFactorWeakPassword, v2.RiskFactor_SEVERITY_MEDIUM))
+	}
+	return factors
 }
 
 // mapRiskFactorSeverity maps CrowdStrike's ScoreSeverity enum (NORMAL, MEDIUM, HIGH)

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -21,8 +21,8 @@ type securityInsightResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	ipClient     *IdentityProtectionClient
-	// enabled gates risk-score ingestion. When false (the default), List is a no-op
-	// that makes no Identity Protection API call — the capability is opt-in.
+	// enabled gates risk-score ingestion (on by default). When false, List is a
+	// no-op that makes no Identity Protection API call.
 	enabled bool
 }
 
@@ -103,8 +103,8 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 }
 
 func (s *securityInsightResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
-	// Opt-in: when risk-score ingestion is disabled, sync nothing and make no
-	// Identity Protection API call.
+	// When risk-score ingestion is disabled, sync nothing and make no Identity
+	// Protection API call.
 	if !s.enabled {
 		return nil, &rs.SyncOpResults{}, nil
 	}

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -21,6 +21,9 @@ type securityInsightResourceType struct {
 	resourceType *v2.ResourceType
 	client       *fClient.CrowdStrikeAPISpecification
 	ipClient     *IdentityProtectionClient
+	// enabled gates risk-score ingestion. When false (the default), List is a no-op
+	// that makes no Identity Protection API call — the capability is opt-in.
+	enabled bool
 }
 
 func (s *securityInsightResourceType) ResourceType(_ context.Context) *v2.ResourceType {
@@ -100,6 +103,12 @@ func securityInsightResource(identity IdentityRiskData, account AccountData) (*v
 }
 
 func (s *securityInsightResourceType) List(ctx context.Context, _ *v2.ResourceId, opts rs.SyncOpAttrs) ([]*v2.Resource, *rs.SyncOpResults, error) {
+	// Opt-in: when risk-score ingestion is disabled, sync nothing and make no
+	// Identity Protection API call.
+	if !s.enabled {
+		return nil, &rs.SyncOpResults{}, nil
+	}
+
 	// Parse the page token to get the cursor
 	cursor := opts.PageToken.Token
 
@@ -174,10 +183,11 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string) *securityInsightResourceType {
+func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string, enabled bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
 		ipClient:     NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		enabled:      enabled,
 	}
 }

--- a/pkg/connector/security_insight.go
+++ b/pkg/connector/security_insight.go
@@ -9,6 +9,7 @@ import (
 
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
+	"github.com/conductorone/baton-sdk/pkg/uhttp"
 	fClient "github.com/crowdstrike/gofalcon/falcon/client"
 )
 
@@ -183,11 +184,11 @@ func mapRiskFactorSeverity(severity string) v2.RiskFactor_Severity {
 	}
 }
 
-func securityInsightBuilder(ctx context.Context, client *fClient.CrowdStrikeAPISpecification, clientID, clientSecret, host string, enabled bool) *securityInsightResourceType {
+func securityInsightBuilder(client *fClient.CrowdStrikeAPISpecification, httpClient *uhttp.BaseHttpClient, host string, enabled bool) *securityInsightResourceType {
 	return &securityInsightResourceType{
 		resourceType: resourceTypeSecurityInsight,
 		client:       client,
-		ipClient:     NewIdentityProtectionClient(ctx, clientID, clientSecret, host),
+		ipClient:     NewIdentityProtectionClient(httpClient, host),
 		enabled:      enabled,
 	}
 }

--- a/pkg/connector/security_insight_test.go
+++ b/pkg/connector/security_insight_test.go
@@ -1,0 +1,97 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/conductorone/baton-sdk/pkg/annotations"
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+)
+
+type wantFactor struct {
+	desc string
+	sev  v2.RiskFactor_Severity
+}
+
+func TestPasswordRiskFactors(t *testing.T) {
+	tests := []struct {
+		name string
+		pa   *PasswordAttributes
+		want []wantFactor
+	}{
+		{name: "nil attributes -> none", pa: nil},
+		{name: "strong, not exposed -> none", pa: &PasswordAttributes{Exposed: false, Strength: "STRONG"}},
+		{name: "unknown strength -> none", pa: &PasswordAttributes{Strength: "UNKNOWN"}},
+		{
+			name: "exposed -> high",
+			pa:   &PasswordAttributes{Exposed: true, Strength: "STRONG"},
+			want: []wantFactor{{riskFactorExposedPassword, v2.RiskFactor_SEVERITY_HIGH}},
+		},
+		{
+			name: "weak (case-insensitive) -> medium",
+			pa:   &PasswordAttributes{Strength: "weak"},
+			want: []wantFactor{{riskFactorWeakPassword, v2.RiskFactor_SEVERITY_MEDIUM}},
+		},
+		{
+			name: "exposed + weak -> both",
+			pa:   &PasswordAttributes{Exposed: true, Strength: "WEAK"},
+			want: []wantFactor{
+				{riskFactorExposedPassword, v2.RiskFactor_SEVERITY_HIGH},
+				{riskFactorWeakPassword, v2.RiskFactor_SEVERITY_MEDIUM},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := passwordRiskFactors(AccountData{PasswordAttributes: tt.pa})
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d factors, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, w := range tt.want {
+				if got[i].GetDescription() != w.desc || got[i].GetSeverity() != w.sev {
+					t.Errorf("factor[%d] = (%s, %v), want (%s, %v)",
+						i, got[i].GetDescription(), got[i].GetSeverity(), w.desc, w.sev)
+				}
+			}
+		})
+	}
+}
+
+// TestSecurityInsightResourcePasswordSignal proves an account whose ONLY risk signal
+// is a compromised (exposed) password still produces a security insight, and that the
+// EXPOSED_PASSWORD risk factor lands on the built resource's trait.
+func TestSecurityInsightResourcePasswordSignal(t *testing.T) {
+	identity := IdentityRiskData{
+		PrimaryDisplayName: "Test User",
+		EmailAddresses:     []string{"test.user@example.com"},
+		// no entity-level RiskFactors — the only signal is the password
+	}
+	account := AccountData{
+		TypeName:           "ActiveDirectoryAccountDescriptor",
+		ObjectGUID:         "682cf9db-abba-432f-b682-5a7fea80a00a", // gives a non-empty ExternalID
+		PasswordAttributes: &PasswordAttributes{Exposed: true, Strength: "UNKNOWN"},
+	}
+
+	res, err := securityInsightResource(identity, account)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected a security insight resource, got nil")
+	}
+
+	var trait v2.SecurityInsightTrait
+	annos := annotations.Annotations(res.GetAnnotations())
+	if _, err := annos.Pick(&trait); err != nil {
+		t.Fatalf("pick security insight trait: %v", err)
+	}
+	factors := trait.GetRiskScore().GetRiskFactors()
+	found := false
+	for _, f := range factors {
+		if f.GetDescription() == riskFactorExposedPassword && f.GetSeverity() == v2.RiskFactor_SEVERITY_HIGH {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an %s (HIGH) risk factor on the insight, got %+v", riskFactorExposedPassword, factors)
+	}
+}

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -55,19 +55,20 @@ func userResource(user *models.DomainUser) (*v2.Resource, error) {
 		profileFieldLastName:  user.LastName,
 	}
 
-	var status v2.UserTrait_Status_Status
+	var status v2.Status_ResourceStatus
 	switch user.Status {
 	case "active":
-		status = v2.UserTrait_Status_STATUS_ENABLED
+		status = v2.Status_RESOURCE_STATUS_ENABLED
 	case "inactive":
-		status = v2.UserTrait_Status_STATUS_DISABLED
+		status = v2.Status_RESOURCE_STATUS_DISABLED
 	default:
-		status = v2.UserTrait_Status_STATUS_UNSPECIFIED
+		status = v2.Status_RESOURCE_STATUS_UNSPECIFIED
 	}
 
-	userTraitOptions := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithStatus(status),
+	var userTraitOptions []rs.UserTraitOption
+	resourceOpts := []rs.ResourceOption{
+		rs.WithResourceProfile(profile),
+		rs.WithResourceStatus(status, ""),
 	}
 
 	if !user.LastLoginAt.IsZero() {
@@ -83,6 +84,7 @@ func userResource(user *models.DomainUser) (*v2.Resource, error) {
 		resourceTypeUser,
 		user.UUID,
 		userTraitOptions,
+		resourceOpts...,
 	)
 
 	if err != nil {


### PR DESCRIPTION
## Summary

Takes over and consolidates the stacked CrowdStrike PRs into one branch on current `main`:

| Source | Feature |
|--------|---------|
| #64 | Shadow MCP (`mcp_server`) + `endpoint_user` + shared EDR snapshot |
| #65 | Identity Protection compromised/weak password risk factors |
| #68 | AI coding tool inventory (`ai_tool`) |

Plus review Critical fix for empty resource types:

- **`OptInRequired`** on `mcp_server`, `endpoint_user`, `ai_tool` (and existing on `security_insight`)
- **Removed connector config kill switches** that emptied List when false (`crowdstrike-detect-shadow-mcp`, `crowdstrike-detect-ai-tools`, `crowdstrike-ingest-risk-scores`) — Forbidden Pattern #2 / silent wipe
- Optional types are gated by **C1 capability mediation only**; List always attempts upstream when C1 schedules the type
- **`crowdstrike-ingest-password-risk`** remains as a non-destructive enrichment filter on insights

Original author work retained with co-authorship history via cherry-pick; rebased onto current main.

Does **not** close #64 / #65 / #68 (operator can close when ready).

## Test plan

- [x] `go test ./...`
- [ ] CI verify + test green on this PR
- [ ] Manual: enable Identity Risk Score capability; confirm risk scores still sync
- [ ] Manual: enable password risk config; confirm EXPOSED_PASSWORD / WEAK_PASSWORD factors
- [ ] Manual: enable Shadow MCP + Endpoint User capabilities; confirm detections path
- [ ] Manual: enable AI Coding Tool capability; confirm inventory path
- [ ] Confirm disabling a capability does not rely on a connector Settings bool that empties List

## Linear / context

Supersedes the review findings on #64 (request-changes: config empty types + missing OptIn).