### PR TITLE
docs: expand password risk into its own section

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -25,7 +25,7 @@ sidebarTitle: "CrowdStrike"
 
 **Additional functionality:**
 
-The CrowdStrike connector supports [external insights](/product/admin/external-insights) when your organization has a Falcon Identity Protection license. See [Enable risk score ingestion](#enable-risk-score-ingestion) for setup instructions.
+The CrowdStrike connector supports [external insights](/product/admin/external-insights) when your organization has a Falcon Identity Protection license. See [Enable risk score ingestion](#enable-risk-score-ingestion) and [Surface identity password risk](#surface-identity-password-risk) for setup instructions.
 
 ## Gather CrowdStrike credentials
 
@@ -248,10 +248,6 @@ spec:
 
 The CrowdStrike connector can ingest Falcon identity risk scores and surface them in C1 during access reviews and access request approvals. See [External insights](/product/admin/external-insights) for an overview of where risk data appears.
 
-<Note>
-**Optional: password risk.** The connector can additionally surface per-account **password risk** as risk factors on the insight — a compromised (exposed) password as a high-severity `EXPOSED_PASSWORD` factor, and a weak password as a medium-severity `WEAK_PASSWORD` factor. This is **opt-in and off by default**: enable the **Ingest identity password risk** setting on the connector to turn it on. No additional scopes are required — it uses the same Identity Protection query.
-</Note>
-
 ### Before you begin
 
 Confirm that:
@@ -288,6 +284,45 @@ The CrowdStrike API client you created during connector setup needs additional s
 Identity risk scores use the **Identity Risk Score** (`security_insight`) capability, which is opt-in in C1. Once the scopes above are in place and the capability is enabled, the connector syncs risk scores automatically. There is no connector config flag that empties this resource type.
 
 **Done.** Your CrowdStrike connector will now sync risk score data into C1. See [External insights](/product/admin/external-insights) for details on where to see this data in the UI.
+
+## Surface identity password risk
+
+<Warning>
+**Early access.** This feature is in early access, which means it's undergoing ongoing testing and development while we gather feedback, validate functionality, and improve outputs. Contact the C1 Support team if you'd like to try it out or share feedback.
+</Warning>
+
+Once risk score ingestion is enabled, you can flag identities with a compromised or weak password from Falcon Identity Protection as risk factors:
+
+- **`EXPOSED_PASSWORD`** (High) — the identity's password appears in a known breach or exposed-credential set (a compromised password).
+- **`WEAK_PASSWORD`** (Medium) — the identity's password is weak.
+
+These are not a separate resource or screen — they appear as **risk factors** on the identity's existing risk insight, in the same places as risk scores (see [Where external insights appear](/product/admin/external-insights#where-external-insights-appear)). A factor is added only when an account has that condition — identities with strong, unexposed passwords carry no password factor.
+
+### Before you begin
+
+Confirm that:
+
+- Risk score ingestion is set up — see [Enable risk score ingestion](#enable-risk-score-ingestion).
+- The **Identity Risk Score** resource capability is turned on for your connector (see [Enable or disable external insights](/product/admin/external-insights#enable-or-disable-external-insights)). Password risk attaches to that insight, so it won't appear if the capability is off.
+- Your CrowdStrike connector is already set up and syncing in C1.
+
+### Turn on password risk
+
+Password risk uses the same Identity Protection scopes as risk score ingestion, so no additional CrowdStrike API scopes are required. Enable it in the connector's settings:
+
+<Steps>
+  <Step>
+  In C1, go to **Integrations** > **Connectors** and select your CrowdStrike connector.
+  </Step>
+  <Step>
+  On the connector's **Settings**, click **Edit**.
+  </Step>
+  <Step>
+  Enable **Ingest identity password risk** (off by default), then click **Save**.
+  </Step>
+</Steps>
+
+**Done.** On the next sync, identities with a compromised or weak password carry the corresponding risk factor, visible wherever external insights appear.
 
 ## Detect shadow MCP servers
 


### PR DESCRIPTION
## Summary
- Replaces the brief password-risk `<Note>` under "Enable risk score ingestion" with a standalone "Surface identity password risk" section (early access warning, factor definitions, prerequisites, and the steps to turn on the **Ingest identity password risk** setting).
- Matches the content added to `baton/crowdstrike.mdx` in the docs repo (ConductorOne/docs #438), so the next connector-docs sync doesn't overwrite it with the thinner version.

## Test plan
- [ ] Confirm the new section renders correctly once synced to the docs site
- [ ] Confirm no duplicate password-risk content remains in the risk-score-ingestion section