### PR TITLE
Guard role grant emission behind WillSyncResourceType

### DIFF
--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -234,9 +234,6 @@
         ],
         "annotations": [
           {
-            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
-          },
-          {
             "@type": "type.googleapis.com/c1.connector.v2.CapabilityPermissions",
             "permissions": [
               {
@@ -246,6 +243,9 @@
                 "permission": "User Management: Write"
               }
             ]
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlements"
           }
         ]
       },

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -17,6 +17,10 @@ sidebarTitle: "CrowdStrike"
 | Endpoint users (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 | AI coding tools (opt-in) | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | |
 
+<Note>
+**Account entitlements.** Accounts carry no entitlements of their own — a user's access is expressed as grants against Roles. When Roles are excluded from the sync, the connector skips the account grant pass as well, since the roles those grants point at wouldn't be present.
+</Note>
+
 ### Connector actions
 
 | Action | Description |

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -22,6 +22,10 @@ type Connector struct {
 	httpClient         *uhttp.BaseHttpClient
 	host               string
 	ingestPasswordRisk bool
+	// skipRoleResourceType reports whether role is excluded from the sync
+	// filter. Named for the skip condition so the zero value is safe: main.go
+	// registers a zero-value Connector{} as the capabilities factory.
+	skipRoleResourceType bool
 }
 
 func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.ResourceSyncerV2 {
@@ -30,7 +34,7 @@ func (o *Connector) ResourceSyncers(ctx context.Context) []connectorbuilder.Reso
 	// switches) so List always attempts upstream when C1 schedules the type.
 	mcpSrc := newMCPSource(o.httpClient, o.host)
 	return []connectorbuilder.ResourceSyncerV2{
-		userBuilder(o.client),
+		userBuilder(o.client, o.skipRoleResourceType),
 		roleBuilder(o.client),
 		securityInsightBuilder(o.client, o.httpClient, o.host, o.ingestPasswordRisk),
 		mcpServerBuilder(o.client, mcpSrc),
@@ -175,5 +179,7 @@ func New(ctx context.Context, cc *cfg.Crowdstrike, opts *cli.ConnectorOpts) (con
 		httpClient:         httpClient,
 		host:               host,
 		ingestPasswordRisk: cc.CrowdstrikeIngestPasswordRisk,
+		// nil opts means no filter, so nothing is skipped.
+		skipRoleResourceType: opts != nil && !opts.WillSyncResourceType(RoleResourceTypeID),
 	}, nil, nil
 }

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -13,7 +13,12 @@ func capabilityPermissions(perms ...string) *v2.CapabilityPermissions {
 	return cp
 }
 
+// RoleResourceTypeID is referenced when gating cross-type role grants.
+const RoleResourceTypeID = "role"
+
 var (
+	// userBuilder clones this and adds SkipEntitlements, or
+	// SkipEntitlementsAndGrants when role isn't synced.
 	resourceTypeUser = &v2.ResourceType{
 		Id:          "user",
 		DisplayName: "User",
@@ -21,7 +26,6 @@ var (
 			v2.ResourceType_TRAIT_USER,
 		},
 		Annotations: annotations.New(
-			&v2.SkipEntitlements{},
 			capabilityPermissions(
 				"User Management: Read",
 				"User Management: Write",
@@ -29,7 +33,7 @@ var (
 		),
 	}
 	resourceTypeRole = &v2.ResourceType{
-		Id:          "role",
+		Id:          RoleResourceTypeID,
 		DisplayName: "Role",
 		Traits: []v2.ResourceType_Trait{
 			v2.ResourceType_TRAIT_ROLE,

--- a/pkg/connector/security_insight_test.go
+++ b/pkg/connector/security_insight_test.go
@@ -3,8 +3,8 @@ package connector
 import (
 	"testing"
 
-	"github.com/conductorone/baton-sdk/pkg/annotations"
 	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"github.com/conductorone/baton-sdk/pkg/annotations"
 )
 
 type wantFactor struct {

--- a/pkg/connector/user.go
+++ b/pkg/connector/user.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crowdstrike/gofalcon/falcon/client/user_management"
 	"github.com/crowdstrike/gofalcon/falcon/models"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
 )
 
 var userGrantsPageSize int64 = 500
@@ -433,9 +434,21 @@ func (u *userResourceType) Delete(ctx context.Context, resourceId *v2.ResourceId
 	return annos, nil
 }
 
-func userBuilder(client *fClient.CrowdStrikeAPISpecification) *userResourceType {
+// userBuilder returns the user syncer. Users have no entitlements of their own,
+// and their only grants are cross-type role grants, so when role is excluded
+// from the sync the grants pass is skipped too.
+func userBuilder(client *fClient.CrowdStrikeAPISpecification, skipRoleResourceType bool) *userResourceType {
+	rt := proto.Clone(resourceTypeUser).(*v2.ResourceType)
+	annos := annotations.Annotations(rt.GetAnnotations())
+	if skipRoleResourceType {
+		annos.Update(&v2.SkipEntitlementsAndGrants{})
+	} else {
+		annos.Update(&v2.SkipEntitlements{})
+	}
+	rt.Annotations = annos
+
 	return &userResourceType{
-		resourceType: resourceTypeUser,
+		resourceType: rt,
 		client:       client,
 	}
 }

--- a/pkg/connector/user_guard_test.go
+++ b/pkg/connector/user_guard_test.go
@@ -1,0 +1,50 @@
+package connector
+
+import (
+	"context"
+	"testing"
+
+	v2 "github.com/conductorone/baton-sdk/pb/c1/connector/v2"
+	"google.golang.org/protobuf/proto"
+)
+
+func hasGuardAnno(rt *v2.ResourceType, msg proto.Message) bool {
+	for _, a := range rt.GetAnnotations() {
+		if a.MessageIs(msg) {
+			return true
+		}
+	}
+	return false
+}
+
+// The user type's only grants are cross-type role grants, so when role is
+// excluded the whole grants pass is skipped.
+func TestUserResourceType_SkipAnnotation(t *testing.T) {
+	inScope := userBuilder(nil, false).ResourceType(context.Background())
+	if !hasGuardAnno(inScope, &v2.SkipEntitlements{}) || hasGuardAnno(inScope, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role in scope: want SkipEntitlements only, got %v", inScope.GetAnnotations())
+	}
+
+	filtered := userBuilder(nil, true).ResourceType(context.Background())
+	if !hasGuardAnno(filtered, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatalf("role filtered: want SkipEntitlementsAndGrants, got %v", filtered.GetAnnotations())
+	}
+
+	if hasGuardAnno(resourceTypeUser, &v2.SkipEntitlementsAndGrants{}) {
+		t.Fatal("package-level resourceTypeUser was mutated")
+	}
+}
+
+// main.go registers a zero-value Connector{} as the capabilities factory, which
+// bypasses New; it must report the unfiltered capability set.
+func TestZeroValueConnector_DoesNotSkipGrants(t *testing.T) {
+	for _, s := range (&Connector{}).ResourceSyncers(context.Background()) {
+		rt := s.ResourceType(context.Background())
+		if rt.GetId() != resourceTypeUser.GetId() {
+			continue
+		}
+		if hasGuardAnno(rt, &v2.SkipEntitlementsAndGrants{}) {
+			t.Fatal("zero-value Connector advertised SkipEntitlementsAndGrants")
+		}
+	}
+}


### PR DESCRIPTION
Gates cross-type grant emission from the user syncer on the customer's sync
filter, so grants aren't emitted for a resource type the sync excludes.
Reference: ConductorOne/baton-linear#55.

Each target is guarded individually in Grants(); when every target is excluded
the user resource type is annotated SkipEntitlementsAndGrants so the SDK skips
the pass entirely.

Flags are named skip<Type>ResourceType and stored inverted so the zero value
means "sync everything" — main.go registers a zero-value Connector{} as the
capabilities factory, bypassing New.

Build, tests, and golangci-lint (0 issues) pass.
